### PR TITLE
Improve api argument handling

### DIFF
--- a/R/get_sidra.R
+++ b/R/get_sidra.R
@@ -382,9 +382,18 @@ get_sidra <- function(x,
     if (!is.character(api)) stop("The 'api' argument must be a character vector")
     if (length(api) != 1) stop("The 'api' argument must have the length equals to 1")
     
-    message("All others arguments are desconsidered when 'api' is informed")
-    
-    path <- httr::content(httr::GET(paste0("https://apisidra.ibge.gov.br/values", api)), as = "text")
+    message("All other arguments are ignored when 'api' is provided.")
+
+    # Strip full URL prefix if user pasted the complete URL
+    base_url <- "https://apisidra.ibge.gov.br/values"
+    api <- sub(base_url, "", api, fixed = TRUE)
+
+    # Ensure api starts with "/"
+    if (!startsWith(api, "/")) {
+      api <- paste0("/", api)
+    }
+
+    path <- httr::content(httr::GET(paste0(base_url, api)), as = "text")
     
     path_header <- "y"
     
@@ -412,8 +421,12 @@ get_sidra <- function(x,
     
   } else if (grepl("Server Error", path)) {
     
-    stop("Server error: Some argument is misspecified or (probabily) The query will result in a table with more than 20k values. 
-         In this case, you may address to the SIDRA's site and request the data manually to be delivered by an email account.")
+    stop(
+      "API request failed. This may be caused by:\n",
+      "- A misspecified argument in the query\n",
+      "- The query exceeding SIDRA's 100,000 row limit\n\n",
+      "For large queries, visit https://sidra.ibge.gov.br to request the data via email."
+    )
   
   } else if ('try-error' %in% class(test1)) {
     
@@ -440,5 +453,5 @@ get_sidra <- function(x,
   }
   
   return(path)
-  
+
 }


### PR DESCRIPTION
## Problem
`get_sidra` fails when a user passes a full URL to the `api` parameter, e.g.:
```r
get_sidra(api = "https://apisidra.ibge.gov.br/values/t/10171/n1/all/v/13544/p/all/c3/59993/c14/200")
```
The function fails because it concatenates the base URL again, resulting in a malformed request. Users copying URLs directly from the SIDRA website face this issue. Also, users who accidentally copy-paste the API parameters without the initial "/" also get an error.

## Fix
Strip the base URL prefix when present so that `api` is more flexible. The three below work.
```r
# These now all work identically:
get_sidra(api = "https://apisidra.ibge.gov.br/values/t/10171/n1/all/v/13544/p/all/c3/59993/c14/200")
get_sidra(api = "/t/10171/n1/all/v/13544/p/all/c3/59993/c14/200")
get_sidra(api = "t/10171/n1/all/v/13544/p/all/c3/59993/c14/200")
```

## Changes
- URL validation for `api` paramter.
- Improved messaging and updated error message (20k -> 100k row limit).

All changes were made by me, but the GitHub PR was made with ClaudeCode (Sonnet 4.6). Closes #25 