### PR TITLE
Prepare sidrar 0.3.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,7 @@
 ^cran-comments\.md$
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
+^\.github$
+^\.gitattributes$
+^vignettes/fig1\.png$
+^vignettes/fig2\.png$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+.Rbuildignore text eol=lf
+DESCRIPTION text eol=lf
+NAMESPACE text eol=lf
+*.R text eol=lf
+*.Rd text eol=lf
+*.Rmd text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: R-CMD-check
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 30
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest, r: "release"}
+          - {os: windows-latest, r: "release"}
+          - {os: ubuntu-latest, r: "devel", http-user-agent: "release"}
+          - {os: ubuntu-latest, r: "release"}
+          - {os: ubuntu-latest, r: "oldrel-1"}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/live-api.yaml
+++ b/.github/workflows/live-api.yaml
@@ -1,0 +1,34 @@
+on:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+name: Live SIDRA API
+
+permissions: read-all
+
+jobs:
+  live-api:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: true
+      SIDRAR_RUN_LIVE_TESTS: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::testthat
+          needs: check
+
+      - name: Run unit and live API tests
+        run: testthat::test_local(reporter = "summary")
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Version: 0.3.0
 Authors@R: person("Renato", "Prado Siqueira", email = "rpradosiqueira@gmail.com", role = c("aut", "cre"))
 Description: Provides a flexible interface to the aggregate data available
     from the Brazilian Institute of Geography and Statistics (IBGE) through
-    its SIDRA application programming interfaces. SIDRA stands for
-    "Sistema IBGE de Recuperação Automática".
+    its SIDRA application programming interfaces. SIDRA is IBGE's system for
+    retrieving aggregate statistical data.
 Depends: R (>= 3.6.0)
 License: GPL-3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,27 +1,27 @@
 Package: sidrar
 Type: Package
 Title: An Interface to IBGE's SIDRA API
-Version: 0.2.9
+Version: 0.3.0
 Authors@R: person("Renato", "Prado Siqueira", email = "rpradosiqueira@gmail.com", role = c("aut", "cre"))
-Description: Allows the user to connect with IBGE's (Instituto Brasileiro de 
-    Geografia e Estatistica, see <https://www.ibge.gov.br/> for more information)
-    SIDRA API in a flexible way. SIDRA is the acronym to "Sistema IBGE de 
-    Recuperacao Automatica" and is the system where IBGE turns available 
-    aggregate data from their researches.
-Depends: R (>= 3.2.0)
+Description: Provides a flexible interface to the aggregate data available
+    from the Brazilian Institute of Geography and Statistics (IBGE) through
+    its SIDRA application programming interfaces. SIDRA stands for
+    "Sistema IBGE de Recuperação Automática".
+Depends: R (>= 3.6.0)
 License: GPL-3
 Encoding: UTF-8
+Language: en-US
 URL: https://github.com/rpradosiqueira/sidrar/
 BugReports: https://github.com/rpradosiqueira/sidrar/issues/
 Imports:
-    magrittr,
     httr,
-    rjson,
-    rvest,
-    stringr,
-    xml2
-RoxygenNote: 7.1.2
+    jsonlite,
+    utils
+RoxygenNote: 8.0.0
+Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat (>= 3.2.0)
+Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,3 @@
 export(get_sidra)
 export(info_sidra)
 export(search_sidra)
-importFrom(magrittr,"%>%")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+# sidrar 0.3.0
+
+* Replaced fragile HTML scraping with official JSON endpoints for table
+  descriptors and the aggregate catalog.
+* Restored `search_sidra()` after changes to the SIDRA website. Searches are
+  now case- and accent-insensitive, support multiple non-adjacent terms, and
+  return table codes as names (#24).
+* Reworked `info_sidra()` while preserving its historical list components:
+  `table`, `period`, `variable`, `classific_category`, and `geo`.
+* Fixed `get_sidra(api = ...)` for complete official HTTPS URLs and preserved
+  percent-encoded paths. Thanks to @viniciusoike for reporting the problem and
+  proposing a solution in #25 and #26.
+* Fixed direct API response parsing so changed or short server responses
+  produce informative package errors instead of failing inside error handling
+  (#16).
+* Requests containing `/h/n` now preserve the first observation instead of
+  treating it as a header.
+* Fixed vector geographic filters and the construction of queries containing
+  multiple classifications and partially specified category lists.
+* Added `value_type` to preserve SIDRA special symbols in a character column
+  or alongside the historical numeric value column (#18).
+* Added HTTPS status checks, informative API errors, UTF-8 decoding, an
+  identifying user agent, configurable timeouts, and retries for transient
+  failures.
+* Added support for intermediary and immediate geographic regions.
+* Reduced runtime dependencies to `httr`, `jsonlite`, and `utils`.
+* Added unit tests, opt-in live API tests, and continuous integration across
+  current R platforms.
+
 # sidrar 0.2.9
 
 * Address SSL error

--- a/R/get_sidra.R
+++ b/R/get_sidra.R
@@ -1,444 +1,187 @@
-#' Get SIDRA's table
+#' Get a SIDRA table
 #'
-#' This function allows the user to connect with IBGE's (Instituto Brasileiro de
-#' Geografia e Estatistica) SIDRA API in a flexible way. \acronym{SIDRA} is the
-#' acronym to "Sistema IBGE de Recuperação Automática" and it is the system where
-#' IBGE makes aggregate data from their researches available.
+#' Retrieves aggregate data from the Brazilian Institute of Geography and
+#' Statistics (IBGE) SIDRA API.
 #'
-#' @usage get_sidra(x, variable = "allxp", period = "last", geo = "Brazil",
-#'   geo.filter = NULL, classific = "all", category = "all", header = TRUE,
-#'   format = 4, digits = "default", api = NULL)
-#' @param x A table from IBGE's SIDRA API.
-#' @param variable An integer vector of the variables' codes to be returned.
-#'   Defaults to all variables with exception of "Total".
-#' @param period A character vector describing the period of data. Defaults to
-#'   the last available.
-#' @param geo A character vector describing the geographic levels of the data.
-#'   Defauts to "Brazil".
-#' @param geo.filter A (named) list object with the specific item of the
-#'   geographic level or all itens of a determined higher geografic level. It should
-#'   be used when geo argument is provided, otherwise all geographic units of
-#'   'geo' argument are considered.
-#' @param classific A character vector with the table's classification(s). Defaults to
-#'   all.
-#' @param category "all" or a list object with the categories of the classifications
-#'   of \code{classific(s)} argument. Defaults to "all".
-#' @param header Logical. should the data frame be returned with the description
-#'   names in header?
-#' @param format An integer ranging between 1 and 4. Default to 4. See more in details.
-#' @param digits An integer, "default" or "max". Default to "default" that returns the
-#'   defaults digits to each variable.
-#' @param api A character with the api's parameters. Defaults to NULL.
+#' @param x A numeric SIDRA table code. It may be omitted when `api` is used.
+#' @param variable A vector of variable codes. Defaults to `"allxp"`, which
+#'   selects all variables except automatically generated percentages.
+#' @param period A character vector of period codes, `"all"`, or a single
+#'   named value such as `c(last = 12)` or `c(first = 5)`.
+#' @param geo A character vector containing supported geographic levels.
+#'   Defaults to `"Brazil"`.
+#' @param geo.filter A list of geographic filters. Each element corresponds
+#'   positionally to an element of `geo`; names may identify a higher
+#'   geographic level, such as `list(State = 50)` for cities in a state.
+#' @param classific A vector of classification codes. Defaults to `"all"`.
+#' @param category `"all"` or a list containing categories for each
+#'   classification.
+#' @param header Logical. Should the first API record be used as the returned
+#'   column names?
+#' @param format An integer from 1 to 4 controlling the returned descriptor
+#'   fields. See Details.
+#' @param digits `"default"`, `"max"`, or an integer from 0 to 9.
+#' @param api A relative SIDRA API path or a complete URL under
+#'   `https://apisidra.ibge.gov.br/values`. When supplied, the other query
+#'   arguments are ignored.
+#' @param value_type How the value column is returned: `"numeric"` preserves
+#'   the historical numeric interface, `"character"` preserves SIDRA symbols,
+#'   and `"both"` keeps the numeric column and appends a `_raw` column.
+#'
 #' @details
-#'   \code{period} can be a integer vector with names "first" and/or "last",
-#'   or "all" or a simply character vector with date format %Y%m-%Y%m.
+#' Supported values of `geo` are `"Brazil"`, `"Region"`, `"State"`,
+#' `"IntermediaryRegion"`, `"ImmediateRegion"`, `"MesoRegion"`,
+#' `"MicroRegion"`, `"MetroRegion"`, `"MetroRegionDiv"`, `"IRD"`,
+#' `"UrbAglo"`, `"PopArrang"`, `"City"`, `"District"`,
+#' `"subdistrict"`, and `"Neighborhood"`.
 #'
-#'   The \code{geo} argument can be one of "Brazil", "Region", "State",
-#'   "MesoRegion", "MicroRegion", "MetroRegion", "MetroRegionDiv", "IRD",
-#'   "UrbAglo", "City", "District","subdistrict","Neighborhood","PopArrang".
-#'   'geo.filter' lists can/must be named with the same characters.
+#' `format = 1` returns codes, `format = 2` returns names, `format = 3`
+#' returns codes and names for geographic units plus names for other
+#' descriptors, and `format = 4` returns codes and names for all descriptors.
 #'
-#'   When NULL, the arguments \code{classific} and \code{category} return all options
-#'   available.
-#'   
-#'   When argument \code{api} is not NULL, all others arguments informed are desconsidered
+#' Requests use HTTPS, UTF-8 decoding, a timeout, and limited retries for
+#' transient failures. Set `options(sidrar.timeout = 120)` or
+#' `options(sidrar.retries = 4)` to override their defaults.
 #'
-#'   The \code{format} argument can be set to:
-#'   \itemize{
-#'      \item 1: Return only the descriptors' codes
-#'      \item 2: Return only the descriptor's names
-#'      \item 3: Return the codes and names of the geographic level and descriptors' names
-#'      \item 4: Return the codes and names of the descriptors (Default)
-#'      }
-#' @return The function returns a data frame printed by default functions
+#' The SIDRA API uses special value symbols. With the default
+#' `value_type = "numeric"`, non-numeric symbols such as `"-"`, `"X"`,
+#' `".."`, and `"..."` become `NA`, as in earlier versions. Use
+#' `value_type = "character"` or `"both"` when those distinctions matter.
+#'
+#' @return A base `data.frame`.
 #' @author Renato Prado Siqueira \email{rpradosiqueira@@gmail.com}
-#' @seealso \code{\link{info_sidra}}
+#' @seealso [info_sidra()] and [search_sidra()]
 #' @examples
 #' \dontrun{
-#' ## Requesting table 1419 (Consumer Price Index - IPCA) from the API
-#' ipca <- get_sidra(1419,
-#'                   variable = 69,
-#'                   period = c("201212","201401-201412"),
-#'                   geo = "City",
-#'                   geo.filter = list("State" = 50))
+#' get_sidra(
+#'   x = 7060,
+#'   variable = 63,
+#'   period = c(last = 12),
+#'   geo = "City",
+#'   geo.filter = list(State = 50),
+#'   classific = "c315",
+#'   category = list(7169)
+#' )
 #'
-#' ## Urban population count from Census data (2010) for States and cities of Southest region.
-#' get_sidra(1378,
-#'           variable = 93,
-#'           geo = c("State","City"),
-#'           geo.filter = list("Region" = 3, "Region" = 3),
-#'           classific = c("c1"),
-#'           category = list(1))
-#'  
-#' ## Number of informants by state in the Inventory Research (last data available) 
-#' get_sidra(api = "/t/254/n1/all/n3/all/v/151/p/last%201/c162/118423/c163/0")
-#' 
+#' get_sidra(
+#'   api = "/t/7060/n1/all/v/63/p/last/c315/7169/h/n"
+#' )
 #' }
-#'
 #' @keywords sidra IBGE
 #' @export
+get_sidra <- function(
+  x,
+  variable = "allxp",
+  period = "last",
+  geo = "Brazil",
+  geo.filter = NULL, # nolint: object_name_linter. Legacy public argument.
+  classific = "all",
+  category = "all",
+  header = TRUE,
+  format = 4,
+  digits = "default",
+  api = NULL,
+  value_type = c("numeric", "character", "both")
+) {
+  value_type <- match.arg(value_type)
 
-get_sidra <- function(x,
-                      variable = "allxp",
-                      period = "last",
-                      geo = "Brazil",
-                      geo.filter = NULL,
-                      classific = "all",
-                      category = "all",
-                      header = TRUE,
-                      format = 4,
-                      digits = "default",
-                      api = NULL) {
-  
   if (is.null(api)) {
-    
-    if (length(x) != 1) {
-      stop("Only one table is allowed")
+    if (missing(x)) {
+      stop("'x' is required when 'api' is not supplied", call. = FALSE)
     }
-    
-    
-    # Variaveis
-    variable = paste(variable, collapse = ",")
-    
-    
-    # Niveis territoriais
-    trad.geo <- data.frame(cod = as.character(c("n1","n2","n3","n8","n9","n7","n13","n14","n15","n23","n6","n10",
-                                                "n11","n102")),
-                           description = as.character(c("Brazil","Region","State","MesoRegion","MicroRegion",
-                                                        "MetroRegion","MetroRegionDiv","IRD","UrbAglo","PopArrang",
-                                                        "City", "District","subdistrict","Neighborhood")),
-                           level = c(1:14))
-    
-    if (sum(!(geo %in% trad.geo$description)) > 0) {
-      
-      a0 <- subset(geo, !(geo %in% trad.geo$description))
-      
-      stop(paste("Some element in 'geo' argument is misspecified:", paste0(a0, collapse = " & ")))
-      
-    }
-    
-    
-    
-    # geo e geo.filter
-    if (is.null(geo) || geo == "Brazil") {
-      
-      path_geo <- "n1/1"
-      
-      if (!is.null(geo.filter)) {
-        message("No filter is necessary in 'geo.filter' argument once 'geo' is set to 'Brazil' (default)")
-      }
-      
-    } else if (length(geo.filter) > length(geo)) {
-      
-      if (is.null(geo) || geo == "Brazil") {
-        
-        message("No filter is necessary in 'geo.filter' argument once 'geo' is set to 'Brazil' (default)")
-        
-      } else {
-        
-        stop("The geo.filter argument must have the same or less length than 'geo'")
-        
-      }
-      
-    } else if (length(geo.filter) <= length(geo)) {
-      
-      for (i in 1:length(geo)) {
-        
-        if (is.null(names(geo.filter[i])) || names(geo.filter[i]) == "") {
-          
-          if (is.null(geo.filter[i])) {
-            
-            geo.filter[i] <- "all"
-            names(geo.filter)[i] <- geo[i]
-            
-          } else {
-            
-            names(geo.filter)[i] <- geo[i]
-            
-          }
-          
-        }
-        
-      }
-      
-      a1 <- 1:length(geo)
-      a2 <- 1:length(geo.filter)
-      a3 <- subset(a1, !(a1 %in% a2))
-      
-      if (any(a3)) {
-        
-        for (j in a3) {
-          
-          geo.filter[[j]]<- "all"
-          names(geo.filter)[[j]] <- geo[j]
-          
-        }
-        
-      }
-      
-      g1 <- data.frame(geo_desc = geo)
-      g1 <- suppressWarnings(merge(g1, trad.geo, by.x = "geo_desc", by.y = "description"))
-      
-      g2 <- data.frame(geo_desc = names(geo.filter))
-      g2 <- suppressWarnings(merge(g2, trad.geo, by.x = "geo_desc", by.y = "description"))
-      names(g2) <- paste0(names(g1), "2")
-      
-      g3 <- cbind(g1, g2)
-      g3$relation <- ifelse(g3$level == g3$level2, 0, ifelse(g3$level < g3$level2, 1, 0))
-      
-      if (sum(g3$relation) != 0) {stop("Some element in 'geo.filter' is misspecified")}
-      
-      g3$relation2 = ifelse(g3$level == g3$level2, 0, 1)
-      
-      path_geo_temp <- list()
-      
-      for (h in 1:length(geo)) {
-        
-        if (g3$relation2[h] == 0) {
-          
-          path_geo_temp[[h]] <- paste0(g3$cod2[h], "/", paste(geo.filter[[h]], collapse = ","))
-          
-        } else {
-          
-          path_geo_temp[[h]] <- paste0(g3$cod[h], "/in%20", g3$cod2[h], "%20", paste(geo.filter[[h]], collapse = ","))
-          
-        }
-        
-      }
-      
-      path_geo <- paste(unlist(path_geo_temp), collapse = "/")
-      
-    }
-    
-    
-    
-    # Classificaoes e categorias (ou secoes)
-    if (is.null(classific) || classific == "all") {
-      
-      if (!is.null(category)) {
-        message("Considering all categories once 'classific' was set to 'all' (default)")
-      }
-      
-      category <- NULL
-      
-      path_classific <- xml2::read_html(paste0("https://apisidra.ibge.gov.br/desctabapi.aspx?c=", x))
-      path_classific <- rvest::html_nodes(path_classific, "table")
-      path_classific <- rvest::html_table(path_classific, fill = TRUE, trim = TRUE)
-      path_classific <- unlist(path_classific)
-      path_classific <- stringr::str_extract(path_classific, "\\C[0-9]+")
-      
-      if (sum(!is.na(path_classific)) == 0) {
-        
-        path_classific <- ""
-        
-      } else {
-        
-        path_classific <- stringr::str_subset(path_classific, "\\C[0-9]+")
-        path_classific <- base::tolower(path_classific)
-        path_classific <- paste0("/", paste0(path_classific, "/all", collapse = "/"))
-        
-      }
-      
-    } else if (!is.null(classific)) {
-      
-      if (is.null(category) || (is.character(category) & category == "all")) {
 
-        path_classific <- paste0("/", paste0(classific, "/all", collapse = "/"))
-        
-      } else if (!is.list(category)) {
-        
-        stop("If not 'all', 'category' must be an object of type 'list'")
-        
-      } else if (length(category) > length(classific)) {
-        
-        stop("The length of 'category' must be equal or less than 'classific' argument")
-        
-      } else if (length(category) == length(classific)) {
-        
-        path_classific <- ""
-        
-        for (i in 1:length(category)) {
-          
-          path_classific <- paste0(path_classific, "/", paste0(classific[i], "/", paste0(category[[i]], collapse = ",")))
-
-        }
-        
-      } else if (length(category) < length(classific)) {
-        
-        for (i in 1:length(category)) {
-          
-          path_classific <- paste0(classific[i], "/", paste0(category[[i]], collapse = ","))
-          
-        }
-        
-        path_classific <- paste0("/", paste0(path_classific, "/", paste0(classific[-c(1:length(category))], "/all", collapse = "/")))
-        
-      }
-      
-    }
-    
-    
-    # period
-    if (!is.character(period) & is.null(names(period))) {
-      
-      stop("The 'period' argument must be an object of type character")
-      
-    } else if (!is.null(names(period))) {
-      
-      if (length(period) != 1) {
-        
-        stop("only one element is possible when named vector ('last' or 'first') is present")
-        
-      } else if(!(names(period) == "last" | names(period) == "first")){
-        
-        stop("The element's 'name' attribute must be 'last' or 'first'")
-        
-      } else {
-        
-        period <- paste0(names(period), "%20", period)
-        
-      }
-      
-      
-    } else {
-      
-      period <- paste0(period, collapse = ",")
-      
-    }
-    
-    
-    # header
-    if ( header == TRUE | header == T) {
-      
-      path_header = "y"
-      
-    } else if (header == FALSE | header == F) {
-      
-      path_header = "n"
-      
-    } else {
-      
-      stop("Only TRUE or FALSE")
-      
-    }
-    
-    
-    # Cod and descriptions
-    if (format == 4 || is.null(format)) {
-      
-      format <- "/f/a"
-      
-    } else if (format == 3) {
-      
-      format <- "/f/u"
-      
-    } else if (format == 2) {
-      
-      format <- "/f/n"
-      
-    } else if (format == 1) {
-      
-      format <- "/f/c"
-      
-    } else {
-      
-      warning("The format argument is misspecified. Considering defaut specification.")
-      
-    }
-    
-    
-    # digits
-    if (digits == "default" || is.null(digits)) {
-      
-      digits <- "/d/s"
-      
-    } else if (digits == "max") {
-      
-      digits <- "/d/m"
-      
-    } else if (digits >= 0 & digits <= 9) {
-      
-      digits <- paste0("/d/", digits)
-      
-    } else {
-      
-      warning("The digits argument is misspecified. Considering defaut specification.")
-      
-    }
-    
-    path <- paste0("https://apisidra.ibge.gov.br/values", 
-                   "/t/", x, "/", 
-                   path_geo, 
-                   "/p/", period,
-                   "/v/", variable, 
-                   path_classific, format, "/h/",
-                   path_header,
-                   digits)
-    
-    path <- httr::content(httr::GET(path), as = "text" )
-    
+    request <- .build_sidra_query(
+      x = x,
+      variable = variable,
+      period = period,
+      geo = geo,
+      geo_filter = geo.filter,
+      classific = classific,
+      category = category,
+      header = header,
+      format = format,
+      digits = digits
+    )
   } else {
-    
-    if (!is.character(api)) stop("The 'api' argument must be a character vector")
-    if (length(api) != 1) stop("The 'api' argument must have the length equals to 1")
-    
-    message("All others arguments are desconsidered when 'api' is informed")
-    
-    path <- httr::content(httr::GET(paste0("https://apisidra.ibge.gov.br/values", api)), as = "text")
-    
-    path_header <- "y"
-    
+    message("All other arguments are ignored when 'api' is provided.")
+    url <- .normalize_api_url(api)
+    request <- list(url = url, header = .api_has_header(url))
   }
-  
 
-  test1 <- try(rjson::fromJSON(path), silent=TRUE)
-  
-  
-  if (strsplit(path, " ")[[1]][2] == "P") {
-    
-    stop("The 'period' argument is misspecified.")
-    
-  } else if (strsplit(path, " ")[[1]][1] == "Tabela" &
-             strsplit(path, " ")[[1]][3] == "Tabela"){
-    
-    ntable <- strsplit(path, " ")[[1]][2]
-    ntable <- substr(ntable, 1, nchar(ntable)-1)
-    
-    stop("This table does not exists.")
-    
-  } else if (strsplit(path, " ")[[1]][2] == "V") {
-    
-    stop(sprintf("The table %s does not contain the %s variable", x, variable))
-    
-  } else if (grepl("Server Error", path)) {
-    
-    stop("Server error: Some argument is misspecified or (probabily) The query will result in a table with more than 20k values. 
-         In this case, you may address to the SIDRA's site and request the data manually to be delivered by an email account.")
-  
-  } else if ('try-error' %in% class(test1)) {
-    
-    stop(path)
-    
+  text <- .sidra_request(request$url)
+  .parse_sidra_values(text, request$header, value_type)
+}
+
+.parse_sidra_values <- function(
+  text,
+  header = TRUE,
+  value_type = c("numeric", "character", "both")
+) {
+  value_type <- match.arg(value_type)
+  parsed <- .sidra_parse_json(
+    text,
+    simplify = TRUE,
+    context = "values response"
+  )
+
+  if (is.data.frame(parsed)) {
+    result <- parsed
+  } else if (is.list(parsed) && length(parsed) == 0L) {
+    result <- data.frame()
   } else {
-    
-    path <- rjson::fromJSON(path)
-    path <- as.data.frame(do.call("rbind", path))
-    
-    path <- as.data.frame(lapply(path, unlist), stringsAsFactors = FALSE)
-
-    if (path_header == "y"){
-      
-      colnames(path) <- unlist(path[1, ])
-      path <- path[-1, ]
-      
-    }
-    
-    id <- which(colnames(path) == "V" | colnames(path) == "Valor")
-    
-    path[ ,id] = suppressWarnings(ifelse(unlist(path[ ,id]) != "..", as.numeric(unlist(path[ ,id])), NA))
-    
+    .sidrar_abort(
+      "SIDRA API returned an unexpected values structure",
+      "sidrar_parse_error"
+    )
   }
-  
-  return(path)
-  
+
+  if (isTRUE(header)) {
+    if (nrow(result) == 0L) {
+      .sidrar_abort(
+        "SIDRA API returned no header record",
+        "sidrar_parse_error"
+      )
+    }
+
+    column_names <- as.character(
+      unlist(result[1L, , drop = FALSE], use.names = FALSE)
+    )
+    if (anyNA(column_names) || any(!nzchar(column_names))) {
+      .sidrar_abort(
+        "SIDRA API returned an invalid header record",
+        "sidrar_parse_error"
+      )
+    }
+
+    names(result) <- column_names
+    result <- result[-1L, , drop = FALSE]
+  }
+
+  value_columns <- which(names(result) %in% c("V", "Valor"))
+  raw_columns <- list()
+
+  for (index in value_columns) {
+    raw <- as.character(result[[index]])
+    value_name <- names(result)[[index]]
+
+    if (identical(value_type, "character")) {
+      result[[index]] <- raw
+    } else {
+      result[[index]] <- suppressWarnings(as.numeric(raw))
+
+      if (identical(value_type, "both")) {
+        raw_columns[[paste0(value_name, "_raw")]] <- raw
+      }
+    }
+  }
+
+  if (length(raw_columns) > 0L) {
+    for (raw_name in names(raw_columns)) {
+      unique_name <- make.unique(c(names(result), raw_name))
+      unique_name <- utils::tail(unique_name, 1L)
+      result[[unique_name]] <- raw_columns[[raw_name]]
+    }
+  }
+
+  result
 }

--- a/R/info_sidra.R
+++ b/R/info_sidra.R
@@ -1,158 +1,164 @@
-#' Listing all the parameters of a SIDRA's table
+#' List the parameters of a SIDRA table
 #'
-#' It returns the parameters and their descriptions of a SIDRA's table.
+#' Uses the official JSON table descriptor to return variables, periods,
+#' classifications, categories, and geographic levels available in a table.
 #'
-#' @param x A table from SIDRA's API.
-#' @param wb Logical. Should the metadata be open in the web browser?
-#'    Default to FALSE.
-#' @return A list with the all table's parameters.
+#' @param x A numeric SIDRA table code.
+#' @param wb Logical. When `TRUE`, open the official HTML descriptor in the
+#'   default browser. When `FALSE`, return structured metadata.
+#'
+#' @return When `wb = FALSE`, a list with components `table`, `period`,
+#'   `variable`, `classific_category`, and `geo`. When `wb = TRUE`, the
+#'   descriptor URL is returned invisibly after the browser is opened.
 #' @author Renato Prado Siqueira \email{rpradosiqueira@@gmail.com}
-#' @seealso \code{\link{get_sidra}}
+#' @seealso [get_sidra()]
 #' @examples
 #' \dontrun{
-#' info_sidra(1419)
+#' info_sidra(7060)
+#' info_sidra(7060, wb = TRUE)
 #' }
-#'
 #' @keywords sidra IBGE
 #' @export
-
-
 info_sidra <- function(x, wb = FALSE) {
-
-  if (!is.logical(wb)) {
-
-    stop("'wb' argument must be TRUE or FALSE")
-
-  } else if (wb == FALSE || wb == F) {
-
-    a <- xml2::read_html(paste0("http://api.sidra.ibge.gov.br/desctabapi.aspx?c=", x))
-
-    # Tabela
-    tab1 = a %>%
-      rvest::html_nodes("#lblNumeroTabela") %>%
-      rvest::html_text()
-
-    tab2 = a %>%
-      rvest::html_nodes("#lblNomeTabela") %>%
-      rvest::html_text()
-
-    table <- list("table" = paste0("Tabela ", tab1, ": ", tab2))
-
-
-    # Período
-    p1 = a %>%
-      rvest::html_nodes("#lblPeriodoDisponibilidade") %>%
-      rvest::html_text()
-
-    period <- list("period" = p1)
-
-
-    # Variáveis
-    v1 <- a %>% rvest::html_nodes("#lblVariaveis") %>%
-      rvest::html_text()
-
-    v2 <- a %>% rvest::html_table(fill = TRUE, trim = TRUE)
-    v2 <- v2[[2]]
-
-    v3 <- data.frame(cod = apply(v2, 1, stringr::str_extract,"[[:digit:]]+"),
-                     desc = apply(v2, 1, stringr::str_replace_all, "([[:digit:]])", ""))
-    v3$cod <- stringr::str_trim(v3$cod)
-    v3$desc <- stringr::str_trim(v3$desc)
-    v3$desc <- stringr::str_replace(v3$desc, " - casas decimais:  padr\uE3o = , m\uE1ximo =", "")
-
-    variables <- list("variable" = v3)
-
-    # Classificações e categorias
-    c1 <- rvest::html_nodes(a, "table") %>%
-      rvest::html_table(fill = TRUE, trim = TRUE) %>%
-      unlist() %>%
-      stringr::str_extract("\\C[0-9]+") %>%
-      stringr::str_subset("\\C[0-9]+") %>%
-      base::tolower()
-
-    if (length(c1) >= 1) {
-
-      lc1 <- length(c1)
-
-      c2 <- a %>% rvest::html_nodes(".tituloLinha:nth-child(4)") %>% rvest::html_text()
-
-      c3 <- a %>% rvest::html_nodes(".tituloLinha:nth-child(5)") %>% rvest::html_text()
-
-      c4 <- paste(c1, "=", c2, c3)
-
-      c5 <- list()
-
-      for (i in 0:(lc1-1)) {
-
-        c5[[i+1]] <- a %>% rvest::html_nodes(paste0("#lstClassificacoes_lblQuantidadeCategorias_", i, "+ ", "#tabPrincipal span")) %>%
-          rvest::html_text() %>%  stringr::str_replace("\\[[^]]*]", "NA")
-        c5[[i+1]] <- c5[[i+1]][c5[[i+1]] != "NA"]
-        c5[[i+1]] <-  data.frame(cod =  c5[[i+1]][seq(1, length(c5[[i+1]]), 2)],
-                                 desc = c5[[i+1]][seq(2, length(c5[[i+1]]), 2)])
-
-      }
-
-      names(c5) <- c4
-
-      classific_category <- list("classific_category" = c5)
-
-    } else {
-
-      classific_category <- list("classific_category" = NULL)
-
-    }
-
-
-
-    # Níveis Territoriais
-    trad.geo <- data.frame(cod = as.character(c("n1","n2","n3","n8","n9","n7","n13","n14","n15","n23","n6","n10",
-                                                "n11","n102")),
-                           cod2 = as.character(c("Brazil","Region","State","MesoRegion","MicroRegion",
-                                                 "MetroRegion","MetroRegionDiv","IRD","UrbAglo","PopArrang",
-                                                 "City", "District","subdistrict","Neighborhood")),
-                           level = c(1:14),
-                           order = c(1:5, 10:14, 6:9))
-
-
-    n1 <- rvest::html_nodes(a, "table") %>%
-      rvest::html_table(fill = TRUE, trim = TRUE) %>%
-      unlist() %>%
-      stringr::str_extract("N[0-9]+") %>%
-      stringr::str_subset("N[0-9]+") %>%
-      tolower() %>%
-      as.data.frame()
-
-    n2 <- a %>% rvest::html_nodes("p+ #tabPrincipal span:nth-child(4)") %>% rvest::html_text()
-    n3 <- a %>% rvest::html_nodes("p+ #tabPrincipal span:nth-child(5)") %>% rvest::html_text()
-    n4 <- data.frame(desc = paste(n2, n3))
-
-    n5 <- cbind(n1, n4)
-
-    ngeo <-  merge(trad.geo, n5, by.x = "cod", by.y = ".")
-    ngeo <- ngeo[c("cod2","desc")]
-    names(ngeo) <- c("cod","desc")
-
-    ngeo <- list(geo = ngeo)
-
-    info <- c(table, period, variables, classific_category, ngeo)
-
-    return(info)
-
-
-  } else if (wb == TRUE || wb == T) {
-
-    p <- readline(prompt = "Can the web browser be open? (y/n): ")
-
-    if (p == "y" | p == "Y") {
-
-      shell.exec(paste0("http://api.sidra.ibge.gov.br/desctabapi.aspx?c=", x))
-
-    } else {
-
-      stop(paste("Sorry, I need your permission to show the parameters of the table", x))
-
-    }
-
+  table <- .validate_table(x)
+  if (!is.logical(wb) || length(wb) != 1L || is.na(wb)) {
+    stop("'wb' argument must be TRUE or FALSE", call. = FALSE)
   }
 
+  if (wb) {
+    url <- paste0(.sidra_descriptor_html_base, table)
+    .open_sidra_descriptor(url)
+    return(invisible(url))
+  }
+
+  .descriptor_to_legacy_info(.fetch_descriptor(table))
+}
+
+.descriptor_to_legacy_info <- function(descriptor) {
+  if (!is.list(descriptor) || is.null(descriptor$Id) ||
+        is.null(descriptor$Nome)) {
+    .sidrar_abort(
+      "SIDRA API returned an invalid table descriptor",
+      "sidrar_parse_error"
+    )
+  }
+
+  table <- list(
+    table = paste0(
+      "Tabela ", .scalar_text(descriptor$Id), ": ",
+      .scalar_text(descriptor$Nome)
+    )
+  )
+
+  period_description <- .scalar_text(descriptor$PeriodoDisponibilidade)
+  if (!nzchar(period_description)) {
+    periods <- descriptor$Periodos
+    period_codes <- if (is.null(periods) || length(periods) == 0L) {
+      character()
+    } else {
+      vapply(periods, function(x) .scalar_text(x$Codigo), character(1))
+    }
+    period_description <- paste(period_codes, collapse = ", ")
+  }
+  period <- list(period = period_description)
+
+  variables <- descriptor$Variaveis
+  variable_data <- if (is.null(variables) || length(variables) == 0L) {
+    data.frame(
+      cod = character(),
+      desc = character(),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    rows <- lapply(variables, function(variable) {
+      description <- .scalar_text(variable$Nome)
+      unit <- .scalar_text(variable$UnidadeMedida)
+      exception <- .scalar_text(variable$PeriodoDisponibilidadeExcecao)
+
+      if (nzchar(unit)) {
+        description <- paste0(description, " (", unit, ")")
+      }
+      if (nzchar(exception)) {
+        description <- paste0(description, " [", exception, "]")
+      }
+
+      data.frame(
+        cod = .scalar_text(variable$Id),
+        desc = description,
+        stringsAsFactors = FALSE
+      )
+    })
+    do.call(rbind, rows)
+  }
+  variable <- list(variable = variable_data)
+
+  classifications <- descriptor$Classificacoes
+  if (is.null(classifications) || length(classifications) == 0L) {
+    classification_data <- NULL
+  } else {
+    classification_data <- lapply(classifications, function(classification) {
+      categories <- classification$Categorias
+      if (is.null(categories) || length(categories) == 0L) {
+        data.frame(
+          cod = character(),
+          desc = character(),
+          stringsAsFactors = FALSE
+        )
+      } else {
+        rows <- lapply(categories, function(category) {
+          data.frame(
+            cod = .scalar_text(category$Id),
+            desc = .scalar_text(category$Nome),
+            stringsAsFactors = FALSE
+          )
+        })
+        do.call(rbind, rows)
+      }
+    })
+
+    names(classification_data) <- vapply(
+      classifications,
+      function(classification) {
+        paste0(
+          "c", .scalar_text(classification$Id),
+          " = ", .scalar_text(classification$Nome),
+          " (", length(classification$Categorias), ")"
+        )
+      },
+      character(1)
+    )
+  }
+  classific_category <- list(classific_category = classification_data)
+
+  levels <- descriptor$NiveisTerritoriais
+  if (is.null(levels) || length(levels) == 0L) {
+    geo_data <- data.frame(
+      cod = character(),
+      desc = character(),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    dictionary <- .geo_dictionary()
+    rows <- lapply(levels, function(level) {
+      code <- paste0("n", .scalar_text(level$Id))
+      index <- match(code, dictionary$code)
+      alias <- if (is.na(index)) code else dictionary$description[[index]]
+
+      data.frame(
+        code = code,
+        cod = alias,
+        desc = paste0(
+          .scalar_text(level$Nome),
+          " (", .scalar_text(level$QuantidadeUnidadesAtivas, "0"), ")"
+        ),
+        stringsAsFactors = FALSE
+      )
+    })
+    geo_data <- do.call(rbind, rows)
+    geo_data <- geo_data[order(geo_data$code), c("cod", "desc"), drop = FALSE]
+    rownames(geo_data) <- NULL
+  }
+  geo <- list(geo = geo_data)
+
+  c(table, period, variable, classific_category, geo)
 }

--- a/R/query.R
+++ b/R/query.R
@@ -1,0 +1,434 @@
+.geo_dictionary <- function() {
+  data.frame(
+    code = c(
+      "n1", "n2", "n3", "n24", "n25", "n8", "n9", "n7",
+      "n13", "n14", "n15", "n23", "n6", "n10", "n11", "n102"
+    ),
+    description = c(
+      "Brazil", "Region", "State", "IntermediaryRegion",
+      "ImmediateRegion", "MesoRegion", "MicroRegion", "MetroRegion",
+      "MetroRegionDiv", "IRD", "UrbAglo", "PopArrang", "City",
+      "District", "subdistrict", "Neighborhood"
+    ),
+    rank = seq_len(16L),
+    stringsAsFactors = FALSE
+  )
+}
+
+.is_all <- function(x) {
+  is.atomic(x) &&
+    length(x) == 1L &&
+    !is.na(x) &&
+    identical(tolower(as.character(x)), "all")
+}
+
+.collapse_codes <- function(x, argument) {
+  x <- unlist(x, use.names = FALSE)
+  if (length(x) == 0L) {
+    return("all")
+  }
+  if (anyNA(x)) {
+    stop(sprintf("'%s' cannot contain missing values", argument), call. = FALSE)
+  }
+
+  x <- as.character(x)
+  if (any(!nzchar(x))) {
+    stop(sprintf("'%s' cannot contain empty values", argument), call. = FALSE)
+  }
+
+  gsub(" ", "%20", paste(x, collapse = ","), fixed = TRUE)
+}
+
+.build_geo_path <- function(geo, geo_filter = NULL) {
+  dictionary <- .geo_dictionary()
+
+  if (is.null(geo)) {
+    geo <- "Brazil"
+  }
+  if (!is.character(geo) || length(geo) == 0L || anyNA(geo)) {
+    stop("'geo' must be a non-empty character vector", call. = FALSE)
+  }
+
+  invalid <- geo[!geo %in% dictionary$description]
+  if (length(invalid) > 0L) {
+    stop(
+      paste0(
+        "Some element in 'geo' argument is misspecified: ",
+        paste(invalid, collapse = " & ")
+      ),
+      call. = FALSE
+    )
+  }
+
+  if (length(geo) == 1L && identical(geo, "Brazil")) {
+    if (!is.null(geo_filter)) {
+      message(
+        "No filter is necessary in 'geo.filter' argument once ",
+        "'geo' is set to 'Brazil' (default)"
+      )
+    }
+    return("n1/1")
+  }
+
+  if (is.null(geo_filter)) {
+    filters <- vector("list", length(geo))
+  } else if (is.list(geo_filter)) {
+    filters <- geo_filter
+  } else {
+    filters <- as.list(geo_filter)
+  }
+
+  if (length(filters) > length(geo)) {
+    stop(
+      "The geo.filter argument must have the same or less length than 'geo'",
+      call. = FALSE
+    )
+  }
+
+  filter_names <- names(filters)
+  if (is.null(filter_names)) {
+    filter_names <- rep("", length(filters))
+  }
+
+  missing_filters <- length(geo) - length(filters)
+  if (missing_filters > 0L) {
+    filters <- c(filters, rep(list("all"), missing_filters))
+    filter_names <- c(filter_names, rep("", missing_filters))
+  }
+
+  for (i in seq_along(geo)) {
+    if (is.null(filters[[i]]) || length(filters[[i]]) == 0L) {
+      filters[[i]] <- "all"
+    }
+    if (!nzchar(filter_names[[i]])) {
+      filter_names[[i]] <- geo[[i]]
+    }
+  }
+
+  invalid_filters <- filter_names[
+    !filter_names %in% dictionary$description
+  ]
+  if (length(invalid_filters) > 0L) {
+    stop("Some element in 'geo.filter' is misspecified", call. = FALSE)
+  }
+
+  geo_index <- match(geo, dictionary$description)
+  filter_index <- match(filter_names, dictionary$description)
+  if (any(dictionary$rank[filter_index] > dictionary$rank[geo_index])) {
+    stop("Some element in 'geo.filter' is misspecified", call. = FALSE)
+  }
+
+  paths <- character(length(geo))
+  for (i in seq_along(geo)) {
+    values <- .collapse_codes(filters[[i]], "geo.filter")
+    geo_code <- dictionary$code[[geo_index[[i]]]]
+    filter_code <- dictionary$code[[filter_index[[i]]]]
+
+    if (identical(geo_code, filter_code)) {
+      paths[[i]] <- paste0(geo_code, "/", values)
+    } else {
+      paths[[i]] <- paste0(
+        geo_code, "/in%20", filter_code, "%20", values
+      )
+    }
+  }
+
+  paste(paths, collapse = "/")
+}
+
+.normalize_classifications <- function(classific) {
+  if ((!is.character(classific) && !is.numeric(classific)) ||
+        length(classific) == 0L || anyNA(classific)) {
+    stop("'classific' must be a non-empty vector", call. = FALSE)
+  }
+
+  classific <- tolower(as.character(classific))
+  valid <- grepl("^c?[0-9]+$", classific)
+  if (any(!valid)) {
+    stop("Some element in 'classific' is misspecified", call. = FALSE)
+  }
+
+  ifelse(startsWith(classific, "c"), classific, paste0("c", classific))
+}
+
+.build_classification_path <- function(classific, category = "all") {
+  if (length(classific) == 0L) {
+    return("")
+  }
+
+  classific <- .normalize_classifications(classific)
+
+  if (is.null(category) || .is_all(category)) {
+    categories <- rep(list("all"), length(classific))
+  } else {
+    if (!is.list(category)) {
+      stop(
+        "If not 'all', 'category' must be an object of type 'list'",
+        call. = FALSE
+      )
+    }
+    if (length(category) > length(classific)) {
+      stop(
+        paste(
+          "The length of 'category' must be equal or less than",
+          "'classific' argument"
+        ),
+        call. = FALSE
+      )
+    }
+
+    categories <- category
+    if (length(categories) < length(classific)) {
+      categories <- c(
+        categories,
+        rep(list("all"), length(classific) - length(categories))
+      )
+    }
+  }
+
+  selections <- vapply(
+    categories,
+    .collapse_codes,
+    character(1),
+    argument = "category"
+  )
+
+  paste0("/", paste0(classific, "/", selections, collapse = "/"))
+}
+
+.descriptor_classifications <- function(descriptor) {
+  classifications <- descriptor$Classificacoes
+  if (is.null(classifications) || length(classifications) == 0L) {
+    return(character())
+  }
+
+  vapply(
+    classifications,
+    function(x) paste0("c", .scalar_text(x$Id)),
+    character(1)
+  )
+}
+
+.resolve_classification_path <- function(table, classific, category) {
+  if (is.null(classific) || .is_all(classific)) {
+    if (!is.null(category) && !.is_all(category)) {
+      message(
+        "Considering all categories once 'classific' was set to ",
+        "'all' (default)"
+      )
+    }
+
+    descriptor <- .fetch_descriptor(table)
+    classific <- .descriptor_classifications(descriptor)
+    return(.build_classification_path(classific, "all"))
+  }
+
+  .build_classification_path(classific, category)
+}
+
+.build_period_path <- function(period) {
+  if (length(period) == 0L || anyNA(period)) {
+    stop("'period' must not be empty or contain missing values", call. = FALSE)
+  }
+
+  period_names <- names(period)
+  has_names <- !is.null(period_names) && any(nzchar(period_names))
+
+  if (has_names) {
+    if (length(period) != 1L) {
+      stop(
+        paste(
+          "Only one element is possible when a named vector",
+          "('last' or 'first') is present"
+        ),
+        call. = FALSE
+      )
+    }
+    if (!period_names[[1L]] %in% c("last", "first")) {
+      stop(
+        "The element's 'name' attribute must be 'last' or 'first'",
+        call. = FALSE
+      )
+    }
+
+    return(paste0(period_names[[1L]], "%20", as.character(period[[1L]])))
+  }
+
+  if (!is.character(period)) {
+    stop(
+      "The 'period' argument must be an object of type character",
+      call. = FALSE
+    )
+  }
+
+  paste(period, collapse = ",")
+}
+
+.build_variable_path <- function(variable) {
+  if ((!is.character(variable) && !is.numeric(variable)) ||
+        length(variable) == 0L || anyNA(variable)) {
+    stop("'variable' must be a non-empty vector", call. = FALSE)
+  }
+
+  paste(as.character(variable), collapse = ",")
+}
+
+.build_header_path <- function(header) {
+  if (!is.logical(header) || length(header) != 1L || is.na(header)) {
+    stop("'header' must be either TRUE or FALSE", call. = FALSE)
+  }
+
+  if (header) "y" else "n"
+}
+
+.build_format_path <- function(format) {
+  format_map <- c("1" = "c", "2" = "n", "3" = "u", "4" = "a")
+  value <- if (is.null(format)) {
+    "4"
+  } else if (length(format) == 1L && !is.na(format)) {
+    as.character(format)
+  } else {
+    ""
+  }
+
+  if (!value %in% names(format_map)) {
+    warning(
+      "The format argument is misspecified. Considering default specification.",
+      call. = FALSE
+    )
+    value <- "4"
+  }
+
+  paste0("/f/", unname(format_map[[value]]))
+}
+
+.build_digits_path <- function(digits) {
+  value <- if (is.null(digits)) {
+    "default"
+  } else if (length(digits) == 1L && !is.na(digits)) {
+    as.character(digits)
+  } else {
+    ""
+  }
+
+  if (identical(value, "default")) {
+    return("/d/s")
+  }
+  if (identical(value, "max")) {
+    return("/d/m")
+  }
+  if (value %in% as.character(0:9)) {
+    return(paste0("/d/", value))
+  }
+
+  warning(
+    "The digits argument is misspecified. Considering default specification.",
+    call. = FALSE
+  )
+  "/d/s"
+}
+
+.build_sidra_query <- function(
+  x,
+  variable,
+  period,
+  geo,
+  geo_filter,
+  classific,
+  category,
+  header,
+  format,
+  digits
+) {
+  table <- .validate_table(x)
+  geo_path <- .build_geo_path(geo, geo_filter)
+  period_path <- .build_period_path(period)
+  variable_path <- .build_variable_path(variable)
+  classification_path <- .resolve_classification_path(
+    table, classific, category
+  )
+  header_path <- .build_header_path(header)
+
+  url <- paste0(
+    .sidra_values_base,
+    "/t/", table,
+    "/", geo_path,
+    "/p/", period_path,
+    "/v/", variable_path,
+    classification_path,
+    .build_format_path(format),
+    "/h/", header_path,
+    .build_digits_path(digits)
+  )
+
+  list(url = url, header = identical(header_path, "y"))
+}
+
+.normalize_api_url <- function(api) {
+  if (!is.character(api) || length(api) != 1L || is.na(api)) {
+    stop(
+      "The 'api' argument must be a character vector of length 1",
+      call. = FALSE
+    )
+  }
+
+  api <- trimws(api)
+  if (!nzchar(api)) {
+    stop("The 'api' argument must not be empty", call. = FALSE)
+  }
+
+  if (grepl("^https?://", api, ignore.case = TRUE)) {
+    parsed <- httr::parse_url(api)
+    path <- sub("^/+", "", .scalar_text(parsed$path))
+
+    if (!identical(tolower(.scalar_text(parsed$scheme)), "https") ||
+      !identical(
+        tolower(.scalar_text(parsed$hostname)),
+        "apisidra.ibge.gov.br"
+      ) ||
+      !grepl("^values/t/", path, ignore.case = TRUE)) {
+      stop(
+        "'api' must use the official HTTPS SIDRA values endpoint",
+        call. = FALSE
+      )
+    }
+    if (!is.null(parsed$query$formato) &&
+          !identical(tolower(parsed$query$formato), "json")) {
+      stop("Only JSON SIDRA responses are supported", call. = FALSE)
+    }
+
+    return(api)
+  }
+
+  api <- sub("^/+", "", api)
+  api <- sub("^values/+", "", api, ignore.case = TRUE)
+  if (!grepl("^t/", api, ignore.case = TRUE)) {
+    stop("'api' must start with a SIDRA table parameter ('t/')", call. = FALSE)
+  }
+
+  url <- paste0(.sidra_values_base, "/", api)
+  parsed <- httr::parse_url(url)
+  if (!is.null(parsed$query$formato) &&
+        !identical(tolower(parsed$query$formato), "json")) {
+    stop("Only JSON SIDRA responses are supported", call. = FALSE)
+  }
+
+  url
+}
+
+.api_has_header <- function(url) {
+  path <- .scalar_text(httr::parse_url(url)$path)
+  parts <- strsplit(path, "/", fixed = TRUE)[[1L]]
+  header_index <- which(tolower(parts) == "h")
+
+  if (length(header_index) == 0L) {
+    return(TRUE)
+  }
+
+  index <- utils::tail(header_index, 1L)
+  if (index >= length(parts)) {
+    return(TRUE)
+  }
+
+  !identical(tolower(parts[[index + 1L]]), "n")
+}

--- a/R/search_sidra.R
+++ b/R/search_sidra.R
@@ -1,29 +1,72 @@
-#' Search SIDRA's tables with determined term(s)
+#' Search SIDRA tables
 #'
-#' It returns all SIDRA's tables with determined term
+#' Searches table titles in the official IBGE aggregate catalog.
 #'
-#' @param x A character vector with the term(s)/word(s) to search.
-#' @return A character vector with the tables' names.
+#' @param x A non-empty character vector containing the search terms.
+#'
+#' @return A named character vector with matching SIDRA table titles. Names
+#'   are the table codes.
 #' @author Renato Prado Siqueira \email{rpradosiqueira@@gmail.com}
-#' @seealso \code{\link{get_sidra}}
+#' @seealso [get_sidra()] and [info_sidra()]
 #' @examples
 #' \dontrun{
 #' search_sidra("contas nacionais")
+#' search_sidra("IPCA")
 #' }
-#'
 #' @keywords sidra IBGE
-#' @importFrom magrittr %>%
 #' @export
-
 search_sidra <- function(x) {
+  if (!is.character(x) || length(x) == 0L || anyNA(x)) {
+    stop("'x' must be a non-empty character vector", call. = FALSE)
+  }
 
-  x <- gsub(" ", "%20", x)
+  x <- trimws(x)
+  if (any(!nzchar(x))) {
+    stop("'x' must not contain empty search terms", call. = FALSE)
+  }
 
-  a <- xml2::read_html(paste0("https://sidra.ibge.gov.br/Busca?q=", paste0(x, collapse = "%20")))
+  catalog <- .fetch_aggregate_catalog()
+  matches <- unlist(
+    lapply(catalog, function(group) {
+      aggregates <- group$agregados
+      if (is.null(aggregates) || length(aggregates) == 0L) {
+        return(list())
+      }
+      lapply(
+        aggregates,
+        function(aggregate) {
+          list(
+            id = .scalar_text(aggregate$id),
+            title = .scalar_text(aggregate$nome)
+          )
+        }
+      )
+    }),
+    recursive = FALSE
+  )
 
-  s <- a %>%
-    rvest::html_nodes(".busca-link-tabela") %>%
-    rvest::html_text()
+  ids <- vapply(matches, function(match) match$id, character(1))
+  titles <- vapply(matches, function(match) match$title, character(1))
+  query <- .normalize_search_text(x)
+  normalized_titles <- .normalize_search_text(titles)
+  selected <- Reduce(
+    `&`,
+    lapply(
+      query,
+      function(term) grepl(term, normalized_titles, fixed = TRUE)
+    )
+  )
+  if (!any(selected)) {
+    return(character())
+  }
 
-  return(s)
+  result <- titles[selected]
+  names(result) <- ids[selected]
+  result[!duplicated(names(result))]
+}
+
+.normalize_search_text <- function(x) {
+  normalized <- iconv(x, from = "", to = "ASCII//TRANSLIT")
+  normalized[is.na(normalized)] <- x[is.na(normalized)]
+  tolower(normalized)
 }

--- a/R/search_sidra.R
+++ b/R/search_sidra.R
@@ -66,7 +66,29 @@ search_sidra <- function(x) {
 }
 
 .normalize_search_text <- function(x) {
-  normalized <- iconv(x, from = "", to = "ASCII//TRANSLIT")
-  normalized[is.na(normalized)] <- x[is.na(normalized)]
+  accents <- paste0(
+    "\u00c0\u00c1\u00c2\u00c3\u00c4\u00c5",
+    "\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5",
+    "\u00c8\u00c9\u00ca\u00cb",
+    "\u00e8\u00e9\u00ea\u00eb",
+    "\u00cc\u00cd\u00ce\u00cf",
+    "\u00ec\u00ed\u00ee\u00ef",
+    "\u00d2\u00d3\u00d4\u00d5\u00d6",
+    "\u00f2\u00f3\u00f4\u00f5\u00f6",
+    "\u00d9\u00da\u00db\u00dc",
+    "\u00f9\u00fa\u00fb\u00fc",
+    "\u00c7\u00e7\u00d1\u00f1",
+    "\u00dd\u0178\u00fd\u00ff"
+  )
+  ascii <- paste0(
+    "AAAAAA", "aaaaaa",
+    "EEEE", "eeee",
+    "IIII", "iiii",
+    "OOOOO", "ooooo",
+    "UUUU", "uuuu",
+    "CcNn", "YYyy"
+  )
+  normalized <- chartr(accents, ascii, enc2utf8(x))
+  normalized <- gsub("[\u0300-\u036f]", "", normalized, perl = TRUE)
   tolower(normalized)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,159 @@
+.sidra_values_base <- "https://apisidra.ibge.gov.br/values"
+.sidra_descriptor_base <- "https://apisidra.ibge.gov.br/DescritoresTabela/t"
+.sidra_descriptor_html_base <- "https://apisidra.ibge.gov.br/desctabapi.aspx?c="
+.sidra_catalog_url <- "https://servicodados.ibge.gov.br/api/v3/agregados"
+
+.sidrar_abort <- function(message, class = "sidrar_error") {
+  condition <- structure(
+    list(message = message, call = NULL),
+    class = unique(c(class, "sidrar_error", "error", "condition"))
+  )
+  stop(condition)
+}
+
+.scalar_text <- function(x, default = "") {
+  if (is.null(x) || length(x) == 0L || is.na(x[[1L]])) {
+    return(default)
+  }
+
+  as.character(x[[1L]])
+}
+
+.validate_table <- function(x) {
+  if (length(x) != 1L || is.na(x) || !is.atomic(x)) {
+    stop("'x' must identify exactly one SIDRA table", call. = FALSE)
+  }
+
+  x <- trimws(as.character(x))
+  if (!nzchar(x) || !grepl("^[0-9]+$", x)) {
+    stop("'x' must be a numeric SIDRA table code", call. = FALSE)
+  }
+
+  x
+}
+
+.sidrar_user_agent <- function() {
+  version <- tryCatch(
+    as.character(utils::packageVersion("sidrar")),
+    error = function(e) "development"
+  )
+
+  paste0(
+    "sidrar/", version,
+    " (https://github.com/rpradosiqueira/sidrar)"
+  )
+}
+
+.sidra_request <- function(url) {
+  timeout <- getOption("sidrar.timeout", 60)
+  retries <- getOption("sidrar.retries", 3L)
+
+  if (length(timeout) != 1L || is.na(timeout) ||
+        !is.numeric(timeout) || !is.finite(timeout) || timeout <= 0) {
+    timeout <- 60
+  }
+  if (length(retries) != 1L || is.na(retries) ||
+        !is.numeric(retries) || !is.finite(retries) || retries < 1) {
+    retries <- 3L
+  }
+
+  response <- tryCatch(
+    httr::RETRY(
+      "GET",
+      url,
+      httr::accept_json(),
+      httr::user_agent(.sidrar_user_agent()),
+      httr::timeout(timeout),
+      times = as.integer(retries),
+      pause_base = 0.5,
+      pause_min = 0.5,
+      pause_cap = 4,
+      quiet = TRUE,
+      terminate_on = setdiff(400:499, c(408, 425, 429))
+    ),
+    error = function(e) {
+      .sidrar_abort(
+        paste0("SIDRA request failed: ", conditionMessage(e)),
+        "sidrar_http_error"
+      )
+    }
+  )
+
+  body <- tryCatch(
+    httr::content(response, as = "text", encoding = "UTF-8"),
+    error = function(e) ""
+  )
+  status <- httr::status_code(response)
+
+  if (httr::http_error(response)) {
+    detail <- trimws(gsub("[\r\n]+", " ", body))
+    if (!nzchar(detail)) {
+      detail <- httr::http_status(response)$message
+    }
+    if (nchar(detail) > 500L) {
+      detail <- paste0(substr(detail, 1L, 497L), "...")
+    }
+
+    .sidrar_abort(
+      sprintf("SIDRA API request failed (HTTP %s): %s", status, detail),
+      "sidrar_http_error"
+    )
+  }
+
+  if (!nzchar(body)) {
+    .sidrar_abort(
+      "SIDRA API returned an empty response",
+      "sidrar_parse_error"
+    )
+  }
+
+  body
+}
+
+.sidra_parse_json <- function(text, simplify = FALSE, context = "response") {
+  if (!is.character(text) || length(text) != 1L || is.na(text) ||
+        !nzchar(trimws(text))) {
+    .sidrar_abort(
+      paste0("SIDRA API returned an empty ", context),
+      "sidrar_parse_error"
+    )
+  }
+
+  tryCatch(
+    jsonlite::fromJSON(
+      text,
+      simplifyVector = simplify,
+      simplifyDataFrame = simplify,
+      simplifyMatrix = simplify
+    ),
+    error = function(e) {
+      preview <- trimws(gsub("[\r\n]+", " ", text))
+      if (nchar(preview) > 200L) {
+        preview <- paste0(substr(preview, 1L, 197L), "...")
+      }
+
+      .sidrar_abort(
+        paste0(
+          "SIDRA API returned an invalid ", context, ": ",
+          preview
+        ),
+        "sidrar_parse_error"
+      )
+    }
+  )
+}
+
+.fetch_descriptor <- function(x) {
+  table <- .validate_table(x)
+  text <- .sidra_request(paste0(.sidra_descriptor_base, "/", table))
+  .sidra_parse_json(text, simplify = FALSE, context = "table descriptor")
+}
+
+.fetch_aggregate_catalog <- function() {
+  text <- .sidra_request(.sidra_catalog_url)
+  .sidra_parse_json(text, simplify = FALSE, context = "aggregate catalog")
+}
+
+.open_sidra_descriptor <- function(url) {
+  utils::browseURL(url)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,5 +1,7 @@
 ---
-output: github_document
+output:
+  github_document:
+    html_preview: false
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -14,55 +16,91 @@ knitr::opts_chunk$set(
 
 # sidrar
 
-The goal of *sidrar* is to provide direct access to the data of IBGE's (Brazilian Institute of Geography and Statistics) SIDRA API within the R environment in an easy and flexible way. SIDRA is the acronym to "Sistema IBGE de Recuperação Automática" and it is the system where IBGE makes aggregate data from their researches available.
+[![CRAN status](https://www.r-pkg.org/badges/version/sidrar)](https://CRAN.R-project.org/package=sidrar)
+[![R-CMD-check](https://github.com/rpradosiqueira/sidrar/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rpradosiqueira/sidrar/actions/workflows/R-CMD-check.yaml)
+
+`sidrar` provides direct access from R to aggregate data and metadata
+published by the Brazilian Institute of Geography and Statistics (IBGE).
+SIDRA stands for *Sistema IBGE de Recuperação Automática*.
 
 ## Installation
 
-Install the release version from CRAN:
+Install the released version from CRAN:
 
-```{r , eval = FALSE}
+```{r, eval = FALSE}
 install.packages("sidrar")
 ```
 
-or the development version from github
+Install the development version from GitHub with:
 
-```{r , eval = FALSE}
-# install.packages("devtools")
-devtools::install_github("rpradosiqueira/sidrar")
+```{r, eval = FALSE}
+# install.packages("pak")
+pak::pak("rpradosiqueira/sidrar")
 ```
 
-## Functions
+## Main functions
 
-For the time being, the "sidrar" package contains only three functions:
+The package has three public functions:
 
-```{r, eval=FALSE}
-get_sidra          It recovers data from the given table
-                   according to the parameters
-                   
-info_sidra         It allows you to check what parameters
-                   are available for a table
-                   
-search_sidra       It searches which tables have a particular 
-                   word in their names
-```		   
+- `search_sidra()` searches the current official aggregate catalog.
+- `info_sidra()` lists the parameters available for a table.
+- `get_sidra()` retrieves the selected observations.
 
-## Example
+Table codes are returned as the names of the `search_sidra()` result:
 
-Let's assume that we want the IPCA (Índice de Preços ao Consumidor Amplo) for the city of Campo Grande/MS. However, we want to recover only the overall percentage rate in the last 12 months. To do this simply execute:
+```{r, eval = FALSE}
+search_sidra("IPCA")
+info_sidra(7060)
+```
+
+## Retrieve data
+
+This example requests the monthly IPCA for the general index in Campo
+Grande, Mato Grosso do Sul, over the 12 most recent periods:
 
 ```{r, eval = FALSE}
 library(sidrar)
 
-get_sidra(x = 1419,
-          variable = 63,
-          period = c(last = "12"),
-          geo = "City",
-          geo.filter = 5002704,
-          classific = "c315",
-          category = list(7169),
-          header = FALSE,
-          format = 3)
-
+ipca <- get_sidra(
+  x = 7060,
+  variable = 63,
+  period = c(last = 12),
+  geo = "City",
+  geo.filter = list(City = 5002704),
+  classific = "c315",
+  category = list(7169)
+)
 ```
 
-To more examples, see the vignette ["Introduction to sidrar"](https://CRAN.R-project.org/package=sidrar/vignettes/Introduction_to_sidrar.html).
+You may also pass either a relative API path or a complete official HTTPS
+URL. A request containing `/h/n` is returned without consuming its first
+observation as a header:
+
+```{r, eval = FALSE}
+ipca_brazil <- get_sidra(
+  api = paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/c315/7169"
+  )
+)
+```
+
+## Preserve special values
+
+By default, `Valor` is numeric for compatibility with earlier releases.
+SIDRA also uses symbols such as `"-"`, `"X"`, `".."`, and `"..."`.
+Use `value_type = "character"` to preserve them in `Valor`, or
+`value_type = "both"` to append `Valor_raw` while retaining numeric
+`Valor`:
+
+```{r, eval = FALSE}
+data <- get_sidra(
+  api = "/t/1849/n3/all/v/811/p/2018/c12762/all",
+  value_type = "both"
+)
+```
+
+For more examples, see the
+["Introduction to sidrar"](https://CRAN.R-project.org/package=sidrar/vignettes/Introduction_to_sidrar.html)
+vignette and the
+[official SIDRA API documentation](https://apisidra.ibge.gov.br/home/ajuda).

--- a/README.md
+++ b/README.md
@@ -1,62 +1,94 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-sidrar
-======
 
-[![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/sidrar)](https://CRAN.R-project.org/package=sidrar) [![CRAC\_Downloads](https://cranlogs.r-pkg.org/badges/grand-total/sidrar)](https://CRAN.R-project.org/package=sidrar)
+# sidrar
 
+[![CRAN
+status](https://www.r-pkg.org/badges/version/sidrar)](https://CRAN.R-project.org/package=sidrar)
+[![R-CMD-check](https://github.com/rpradosiqueira/sidrar/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rpradosiqueira/sidrar/actions/workflows/R-CMD-check.yaml)
 
-The goal of *sidrar* is to provide direct access to the data of IBGE's (Brazilian Institute of Geography and Statistics) SIDRA API within the R environment in an easy and flexible way. SIDRA is the acronym to "Sistema IBGE de Recuperação Automática" and it is the system where IBGE makes aggregate data from their researches available.
+`sidrar` provides direct access from R to aggregate data and metadata
+published by the Brazilian Institute of Geography and Statistics (IBGE).
+SIDRA stands for *Sistema IBGE de Recuperação Automática*.
 
-Installation
-------------
+## Installation
 
-Install the release version from CRAN:
+Install the released version from CRAN:
 
 ``` r
 install.packages("sidrar")
 ```
 
-or the development version from github
+Install the development version from GitHub with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("rpradosiqueira/sidrar")
+# install.packages("pak")
+pak::pak("rpradosiqueira/sidrar")
 ```
 
-Functions
----------
+## Main functions
 
-For the time being, the "sidrar" package contains only three functions:
+The package has three public functions:
+
+- `search_sidra()` searches the current official aggregate catalog.
+- `info_sidra()` lists the parameters available for a table.
+- `get_sidra()` retrieves the selected observations.
+
+Table codes are returned as the names of the `search_sidra()` result:
 
 ``` r
-get_sidra          It recovers data from the given table
-                   according to the parameters
-                   
-info_sidra         It allows you to check what parameters
-                   are available for a table
-                   
-search_sidra       It searches which tables have a particular 
-                   word in their names
+search_sidra("IPCA")
+info_sidra(7060)
 ```
 
-Example
--------
+## Retrieve data
 
-Let's assume that we want the IPCA (Índice de Preços ao Consumidor Amplo) for the city of Campo Grande/MS. However, we want to recover only the overall percentage rate in the last 12 months. To do this simply execute:
+This example requests the monthly IPCA for the general index in Campo
+Grande, Mato Grosso do Sul, over the 12 most recent periods:
 
 ``` r
 library(sidrar)
 
-get_sidra(x = 1419,
-          variable = 63,
-          period = c(last = "12"),
-          geo = "City",
-          geo.filter = 5002704,
-          classific = "c315",
-          category = list(7169),
-          header = FALSE,
-          format = 3)
+ipca <- get_sidra(
+  x = 7060,
+  variable = 63,
+  period = c(last = 12),
+  geo = "City",
+  geo.filter = list(City = 5002704),
+  classific = "c315",
+  category = list(7169)
+)
 ```
 
-To more examples, see the vignette ["Introduction to sidrar"](https://CRAN.R-project.org/package=sidrar/vignettes/Introduction_to_sidrar.html).
+You may also pass either a relative API path or a complete official
+HTTPS URL. A request containing `/h/n` is returned without consuming its
+first observation as a header:
+
+``` r
+ipca_brazil <- get_sidra(
+  api = paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/c315/7169"
+  )
+)
+```
+
+## Preserve special values
+
+By default, `Valor` is numeric for compatibility with earlier releases.
+SIDRA also uses symbols such as `"-"`, `"X"`, `".."`, and `"..."`. Use
+`value_type = "character"` to preserve them in `Valor`, or
+`value_type = "both"` to append `Valor_raw` while retaining numeric
+`Valor`:
+
+``` r
+data <- get_sidra(
+  api = "/t/1849/n3/all/v/811/p/2018/c12762/all",
+  value_type = "both"
+)
+```
+
+For more examples, see the [“Introduction to
+sidrar”](https://CRAN.R-project.org/package=sidrar/vignettes/Introduction_to_sidrar.html)
+vignette and the [official SIDRA API
+documentation](https://apisidra.ibge.gov.br/home/ajuda).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,14 +5,19 @@ It replaces HTML scraping with official JSON endpoints, restores table
 search, fixes complete API URLs and header-free responses, and adds tests
 while preserving the existing `get_sidra()` defaults and return schema.
 
-## Test environment
+## Test environments
 
 * Windows 11 x64 (build 26200), R 4.6.0 (ucrt)
+* win-builder, Windows Server 2022 x64, R-devel
+  (2026-07-22 r90289 ucrt)
 
 ## R CMD check results
 
 `R CMD check --as-cran --no-manual` was run on the source tarball with CRAN
 incoming remote checks enabled.
+
+The same source tarball was checked on win-builder with R-devel, including
+the PDF and HTML manuals.
 
 0 errors | 0 warnings | 0 notes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,25 @@
-## New R CMD check results
+## Release summary
 
-0 errors | 0 warnings | 0 note 
+This update modernizes the package after changes to IBGE's SIDRA services.
+It replaces HTML scraping with official JSON endpoints, restores table
+search, fixes complete API URLs and header-free responses, and adds tests
+while preserving the existing `get_sidra()` defaults and return schema.
 
-## Test environments
-* local OS X install, R 3.3.2
-* win-builder (devel and release)
+## Test environment
+
+* Windows 11 x64 (build 26200), R 4.6.0 (ucrt)
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 note 
+`R CMD check --as-cran --no-manual` was run on the source tarball with CRAN
+incoming remote checks enabled.
+
+0 errors | 0 warnings | 0 notes
+
+## Downstream compatibility
+
+The current reverse imports (`datazoom.amazonia`, `PNADCperiods`, and
+`SidraFacil`) were audited for their use of the public API. Compatibility
+tests cover the existing argument order, base `data.frame` output, Portuguese
+column names and order, numeric `Valor`, relative percent-encoded API paths,
+and the historical `info_sidra()` list structure.

--- a/man/get_sidra.Rd
+++ b/man/get_sidra.Rd
@@ -2,101 +2,106 @@
 % Please edit documentation in R/get_sidra.R
 \name{get_sidra}
 \alias{get_sidra}
-\title{Get SIDRA's table}
+\title{Get a SIDRA table}
 \usage{
-get_sidra(x, variable = "allxp", period = "last", geo = "Brazil",
-  geo.filter = NULL, classific = "all", category = "all", header = TRUE,
-  format = 4, digits = "default", api = NULL)
+get_sidra(
+  x,
+  variable = "allxp",
+  period = "last",
+  geo = "Brazil",
+  geo.filter = NULL,
+  classific = "all",
+  category = "all",
+  header = TRUE,
+  format = 4,
+  digits = "default",
+  api = NULL,
+  value_type = c("numeric", "character", "both")
+)
 }
 \arguments{
-\item{x}{A table from IBGE's SIDRA API.}
+\item{x}{A numeric SIDRA table code. It may be omitted when \code{api} is used.}
 
-\item{variable}{An integer vector of the variables' codes to be returned.
-Defaults to all variables with exception of "Total".}
+\item{variable}{A vector of variable codes. Defaults to \code{"allxp"}, which
+selects all variables except automatically generated percentages.}
 
-\item{period}{A character vector describing the period of data. Defaults to
-the last available.}
+\item{period}{A character vector of period codes, \code{"all"}, or a single
+named value such as \code{c(last = 12)} or \code{c(first = 5)}.}
 
-\item{geo}{A character vector describing the geographic levels of the data.
-Defauts to "Brazil".}
+\item{geo}{A character vector containing supported geographic levels.
+Defaults to \code{"Brazil"}.}
 
-\item{geo.filter}{A (named) list object with the specific item of the
-geographic level or all itens of a determined higher geografic level. It should
-be used when geo argument is provided, otherwise all geographic units of
-'geo' argument are considered.}
+\item{geo.filter}{A list of geographic filters. Each element corresponds
+positionally to an element of \code{geo}; names may identify a higher
+geographic level, such as \code{list(State = 50)} for cities in a state.}
 
-\item{classific}{A character vector with the table's classification(s). Defaults to
-all.}
+\item{classific}{A vector of classification codes. Defaults to \code{"all"}.}
 
-\item{category}{"all" or a list object with the categories of the classifications
-of \code{classific(s)} argument. Defaults to "all".}
+\item{category}{\code{"all"} or a list containing categories for each
+classification.}
 
-\item{header}{Logical. should the data frame be returned with the description
-names in header?}
+\item{header}{Logical. Should the first API record be used as the returned
+column names?}
 
-\item{format}{An integer ranging between 1 and 4. Default to 4. See more in details.}
+\item{format}{An integer from 1 to 4 controlling the returned descriptor
+fields. See Details.}
 
-\item{digits}{An integer, "default" or "max". Default to "default" that returns the
-defaults digits to each variable.}
+\item{digits}{\code{"default"}, \code{"max"}, or an integer from 0 to 9.}
 
-\item{api}{A character with the api's parameters. Defaults to NULL.}
+\item{api}{A relative SIDRA API path or a complete URL under
+\verb{https://apisidra.ibge.gov.br/values}. When supplied, the other query
+arguments are ignored.}
+
+\item{value_type}{How the value column is returned: \code{"numeric"} preserves
+the historical numeric interface, \code{"character"} preserves SIDRA symbols,
+and \code{"both"} keeps the numeric column and appends a \verb{_raw} column.}
 }
 \value{
-The function returns a data frame printed by default functions
+A base \code{data.frame}.
 }
 \description{
-This function allows the user to connect with IBGE's (Instituto Brasileiro de
-Geografia e Estatistica) SIDRA API in a flexible way. \acronym{SIDRA} is the
-acronym to "Sistema IBGE de Recuperação Automática" and it is the system where
-IBGE makes aggregate data from their researches available.
+Retrieves aggregate data from the Brazilian Institute of Geography and
+Statistics (IBGE) SIDRA API.
 }
 \details{
-\code{period} can be a integer vector with names "first" and/or "last",
-  or "all" or a simply character vector with date format %Y%m-%Y%m.
+Supported values of \code{geo} are \code{"Brazil"}, \code{"Region"}, \code{"State"},
+\code{"IntermediaryRegion"}, \code{"ImmediateRegion"}, \code{"MesoRegion"},
+\code{"MicroRegion"}, \code{"MetroRegion"}, \code{"MetroRegionDiv"}, \code{"IRD"},
+\code{"UrbAglo"}, \code{"PopArrang"}, \code{"City"}, \code{"District"},
+\code{"subdistrict"}, and \code{"Neighborhood"}.
 
-  The \code{geo} argument can be one of "Brazil", "Region", "State",
-  "MesoRegion", "MicroRegion", "MetroRegion", "MetroRegionDiv", "IRD",
-  "UrbAglo", "City", "District","subdistrict","Neighborhood","PopArrang".
-  'geo.filter' lists can/must be named with the same characters.
+\code{format = 1} returns codes, \code{format = 2} returns names, \code{format = 3}
+returns codes and names for geographic units plus names for other
+descriptors, and \code{format = 4} returns codes and names for all descriptors.
 
-  When NULL, the arguments \code{classific} and \code{category} return all options
-  available.
-  
-  When argument \code{api} is not NULL, all others arguments informed are desconsidered
+Requests use HTTPS, UTF-8 decoding, a timeout, and limited retries for
+transient failures. Set \code{options(sidrar.timeout = 120)} or
+\code{options(sidrar.retries = 4)} to override their defaults.
 
-  The \code{format} argument can be set to:
-  \itemize{
-     \item 1: Return only the descriptors' codes
-     \item 2: Return only the descriptor's names
-     \item 3: Return the codes and names of the geographic level and descriptors' names
-     \item 4: Return the codes and names of the descriptors (Default)
-     }
+The SIDRA API uses special value symbols. With the default
+\code{value_type = "numeric"}, non-numeric symbols such as \code{"-"}, \code{"X"},
+\code{".."}, and \code{"..."} become \code{NA}, as in earlier versions. Use
+\code{value_type = "character"} or \code{"both"} when those distinctions matter.
 }
 \examples{
 \dontrun{
-## Requesting table 1419 (Consumer Price Index - IPCA) from the API
-ipca <- get_sidra(1419,
-                  variable = 69,
-                  period = c("201212","201401-201412"),
-                  geo = "City",
-                  geo.filter = list("State" = 50))
+get_sidra(
+  x = 7060,
+  variable = 63,
+  period = c(last = 12),
+  geo = "City",
+  geo.filter = list(State = 50),
+  classific = "c315",
+  category = list(7169)
+)
 
-## Urban population count from Census data (2010) for States and cities of Southest region.
-get_sidra(1378,
-          variable = 93,
-          geo = c("State","City"),
-          geo.filter = list("Region" = 3, "Region" = 3),
-          classific = c("c1"),
-          category = list(1))
- 
-## Number of informants by state in the Inventory Research (last data available) 
-get_sidra(api = "/t/254/n1/all/n3/all/v/151/p/last\%201/c162/118423/c163/0")
-
+get_sidra(
+  api = "/t/7060/n1/all/v/63/p/last/c315/7169/h/n"
+)
 }
-
 }
 \seealso{
-\code{\link{info_sidra}}
+\code{\link[=info_sidra]{info_sidra()}} and \code{\link[=search_sidra]{search_sidra()}}
 }
 \author{
 Renato Prado Siqueira \email{rpradosiqueira@gmail.com}

--- a/man/info_sidra.Rd
+++ b/man/info_sidra.Rd
@@ -2,30 +2,33 @@
 % Please edit documentation in R/info_sidra.R
 \name{info_sidra}
 \alias{info_sidra}
-\title{Listing all the parameters of a SIDRA's table}
+\title{List the parameters of a SIDRA table}
 \usage{
 info_sidra(x, wb = FALSE)
 }
 \arguments{
-\item{x}{A table from SIDRA's API.}
+\item{x}{A numeric SIDRA table code.}
 
-\item{wb}{Logical. Should the metadata be open in the web browser?
-Default to FALSE.}
+\item{wb}{Logical. When \code{TRUE}, open the official HTML descriptor in the
+default browser. When \code{FALSE}, return structured metadata.}
 }
 \value{
-A list with the all table's parameters.
+When \code{wb = FALSE}, a list with components \code{table}, \code{period},
+\code{variable}, \code{classific_category}, and \code{geo}. When \code{wb = TRUE}, the
+descriptor URL is returned invisibly after the browser is opened.
 }
 \description{
-It returns the parameters and their descriptions of a SIDRA's table.
+Uses the official JSON table descriptor to return variables, periods,
+classifications, categories, and geographic levels available in a table.
 }
 \examples{
 \dontrun{
-info_sidra(1419)
+info_sidra(7060)
+info_sidra(7060, wb = TRUE)
 }
-
 }
 \seealso{
-\code{\link{get_sidra}}
+\code{\link[=get_sidra]{get_sidra()}}
 }
 \author{
 Renato Prado Siqueira \email{rpradosiqueira@gmail.com}

--- a/man/search_sidra.Rd
+++ b/man/search_sidra.Rd
@@ -2,27 +2,28 @@
 % Please edit documentation in R/search_sidra.R
 \name{search_sidra}
 \alias{search_sidra}
-\title{Search SIDRA's tables with determined term(s)}
+\title{Search SIDRA tables}
 \usage{
 search_sidra(x)
 }
 \arguments{
-\item{x}{A character vector with the term(s)/word(s) to search.}
+\item{x}{A non-empty character vector containing the search terms.}
 }
 \value{
-A character vector with the tables' names.
+A named character vector with matching SIDRA table titles. Names
+are the table codes.
 }
 \description{
-It returns all SIDRA's tables with determined term
+Searches table titles in the official IBGE aggregate catalog.
 }
 \examples{
 \dontrun{
 search_sidra("contas nacionais")
+search_sidra("IPCA")
 }
-
 }
 \seealso{
-\code{\link{get_sidra}}
+\code{\link[=get_sidra]{get_sidra()}} and \code{\link[=info_sidra]{info_sidra()}}
 }
 \author{
 Renato Prado Siqueira \email{rpradosiqueira@gmail.com}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(sidrar)
+
+test_check("sidrar")

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -1,0 +1,114 @@
+values_with_header_json <- function() {
+  paste0(
+    '[{"NC":"Nível Territorial (Código)",',
+    '"NN":"Nível Territorial","V":"Valor"},',
+    '{"NC":"1","NN":"Brasil","V":"0.16"}]'
+  )
+}
+
+values_without_header_json <- function() {
+  '[{"NC":"1","NN":"Brasil","V":"0.16"}]'
+}
+
+descriptor_fixture <- function() {
+  list(
+    Id = 1419,
+    Nome = paste(
+      "IPCA - Variação mensal, acumulada no ano,",
+      "acumulada em 12 meses"
+    ),
+    PeriodoDisponibilidade = "janeiro 2012 a fevereiro 2012",
+    Periodos = list(
+      list(Codigo = 201201, Nome = "janeiro 2012"),
+      list(Codigo = 201202, Nome = "fevereiro 2012")
+    ),
+    Variaveis = list(
+      list(
+        Id = 63,
+        Nome = "IPCA - Variação mensal",
+        UnidadeMedida = "%",
+        PeriodoDisponibilidadeExcecao = ""
+      ),
+      list(
+        Id = 2265,
+        Nome = "IPCA - Variação acumulada em 12 meses",
+        UnidadeMedida = "%",
+        PeriodoDisponibilidadeExcecao = "dezembro 2012 a dezembro 2019"
+      )
+    ),
+    Classificacoes = list(
+      list(
+        Id = 315,
+        Nome = "Geral, grupo, subgrupo, item e subitem",
+        Categorias = list(
+          list(Id = 7169, Nome = "Índice geral"),
+          list(Id = 7170, Nome = "Alimentação e bebidas")
+        )
+      )
+    ),
+    NiveisTerritoriais = list(
+      list(
+        Id = 1,
+        Nome = "Brasil",
+        QuantidadeUnidadesAtivas = 1
+      ),
+      list(
+        Id = 7,
+        Nome = "Região Metropolitana até 2020",
+        QuantidadeUnidadesAtivas = 10
+      ),
+      list(
+        Id = 6,
+        Nome = "Município",
+        QuantidadeUnidadesAtivas = 6
+      )
+    )
+  )
+}
+
+catalog_fixture <- function() {
+  list(
+    list(
+      id = "D1",
+      nome = "Preços",
+      agregados = list(
+        list(
+          id = "7060",
+          nome = "IPCA - Variação mensal e acumulada"
+        ),
+        list(
+          id = "1737",
+          nome = "IPCA - Série histórica"
+        )
+      )
+    ),
+    list(
+      id = "D2",
+      nome = "Contas",
+      agregados = list(
+        list(
+          id = "5932",
+          nome = "Sistema de Contas Nacionais"
+        )
+      )
+    )
+  )
+}
+
+fake_http_response <- function(status = 200L, body = "[]") {
+  structure(
+    list(
+      url = "https://apisidra.ibge.gov.br/values/t/1",
+      status_code = as.integer(status),
+      headers = list("content-type" = "application/json; charset=UTF-8"),
+      all_headers = list(),
+      cookies = data.frame(),
+      content = charToRaw(enc2utf8(body)),
+      date = Sys.time(),
+      times = numeric(),
+      request = list(method = "GET"),
+      handle = NULL
+    ),
+    class = "response"
+  )
+}

--- a/tests/testthat/test-info-sidra.R
+++ b/tests/testthat/test-info-sidra.R
@@ -1,0 +1,63 @@
+test_that("JSON descriptors retain the legacy info_sidra structure", {
+  info <- sidrar:::.descriptor_to_legacy_info(descriptor_fixture())
+
+  expect_identical(
+    names(info),
+    c("table", "period", "variable", "classific_category", "geo")
+  )
+  expect_match(info$table, "^Tabela 1419:")
+  expect_identical(info$period, "janeiro 2012 a fevereiro 2012")
+  expect_identical(info$variable$cod, c("63", "2265"))
+  expect_match(info$variable$desc[[2L]], "12 meses", fixed = TRUE)
+  expect_match(
+    info$variable$desc[[2L]],
+    "dezembro 2012 a dezembro 2019",
+    fixed = TRUE
+  )
+  expect_identical(
+    names(info$classific_category),
+    "c315 = Geral, grupo, subgrupo, item e subitem (2)"
+  )
+  expect_identical(
+    info$geo$cod,
+    c("Brazil", "City", "MetroRegion")
+  )
+})
+
+test_that("period codes are a fallback for older descriptor shapes", {
+  descriptor <- descriptor_fixture()
+  descriptor$PeriodoDisponibilidade <- NULL
+
+  info <- sidrar:::.descriptor_to_legacy_info(descriptor)
+  expect_identical(info$period, "201201, 201202")
+})
+
+test_that("info_sidra uses the JSON descriptor and validates wb", {
+  testthat::local_mocked_bindings(
+    .fetch_descriptor = function(x) descriptor_fixture(),
+    .package = "sidrar"
+  )
+
+  info <- info_sidra(1419)
+  expect_identical(info$variable$cod, c("63", "2265"))
+  expect_error(info_sidra(1419, wb = NA), "TRUE or FALSE")
+  expect_error(info_sidra(1419, wb = c(TRUE, FALSE)), "TRUE or FALSE")
+})
+
+test_that("wb uses the portable browser helper without prompting", {
+  opened <- NULL
+  testthat::local_mocked_bindings(
+    .open_sidra_descriptor = function(url) {
+      opened <<- url
+      invisible(TRUE)
+    },
+    .package = "sidrar"
+  )
+
+  result <- info_sidra(1419, wb = TRUE)
+  expect_identical(
+    opened,
+    "https://apisidra.ibge.gov.br/desctabapi.aspx?c=1419"
+  )
+  expect_identical(result, opened)
+})

--- a/tests/testthat/test-live-api.R
+++ b/tests/testthat/test-live-api.R
@@ -1,0 +1,98 @@
+run_live_tests <- function() {
+  identical(tolower(Sys.getenv("SIDRAR_RUN_LIVE_TESTS")), "true")
+}
+
+test_that("the live SIDRA values endpoint returns a current observation", {
+  skip_on_cran()
+  skip_if_not(run_live_tests(), "Set SIDRAR_RUN_LIVE_TESTS=true")
+
+  result <- get_sidra(
+    api = "/t/7060/n1/all/v/63/p/last/c315/7169/h/n"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_gt(nrow(result), 0L)
+  expect_true("V" %in% names(result))
+})
+
+test_that("a structured live query preserves the legacy schema", {
+  skip_on_cran()
+  skip_if_not(run_live_tests(), "Set SIDRAR_RUN_LIVE_TESTS=true")
+
+  result <- get_sidra(
+    x = 7060,
+    variable = 63,
+    period = "last",
+    geo = "City",
+    geo.filter = list(State = 50),
+    classific = "c315",
+    category = list(7169)
+  )
+
+  expect_identical(
+    names(result),
+    c(
+      "Nível Territorial (Código)",
+      "Nível Territorial",
+      "Unidade de Medida (Código)",
+      "Unidade de Medida",
+      "Valor",
+      "Município (Código)",
+      "Município",
+      "Mês (Código)",
+      "Mês",
+      "Variável (Código)",
+      "Variável",
+      "Geral, grupo, subgrupo, item e subitem (Código)",
+      "Geral, grupo, subgrupo, item e subitem"
+    )
+  )
+  expect_type(result$Valor, "double")
+  expect_true(all(vapply(result[-5L], is.character, logical(1))))
+})
+
+test_that("the live values endpoint accepts a complete URL", {
+  skip_on_cran()
+  skip_if_not(run_live_tests(), "Set SIDRAR_RUN_LIVE_TESTS=true")
+
+  url <- paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/c315/7169/h/n"
+  )
+  result <- suppressMessages(get_sidra(api = url))
+
+  expect_s3_class(result, "data.frame")
+  expect_gt(nrow(result), 0L)
+  expect_true("V" %in% names(result))
+})
+
+test_that("live special values can be preserved", {
+  skip_on_cran()
+  skip_if_not(run_live_tests(), "Set SIDRAR_RUN_LIVE_TESTS=true")
+
+  result <- suppressMessages(get_sidra(
+    api = "/t/1849/n3/all/v/811/p/2018/c12762/all",
+    value_type = "both"
+  ))
+
+  expect_true(all(c("Valor", "Valor_raw") %in% names(result)))
+  expect_true(any(result$Valor_raw == "X"))
+  expect_true(all(is.na(result$Valor[result$Valor_raw == "X"])))
+})
+
+test_that("the live descriptor and catalog endpoints respond", {
+  skip_on_cran()
+  skip_if_not(run_live_tests(), "Set SIDRAR_RUN_LIVE_TESTS=true")
+
+  info <- info_sidra(7060)
+  matches <- search_sidra("IPCA")
+
+  expect_identical(
+    names(info),
+    c("table", "period", "variable", "classific_category", "geo")
+  )
+  expect_match(info$period, " a ", fixed = TRUE)
+  expect_type(info$classific_category, "list")
+  expect_match(names(info$classific_category)[[1L]], "^c[0-9]+ ")
+  expect_gt(length(matches), 0L)
+  expect_true(all(nzchar(names(matches))))
+})

--- a/tests/testthat/test-parse-values.R
+++ b/tests/testthat/test-parse-values.R
@@ -1,0 +1,111 @@
+test_that("responses with and without a header keep all data rows", {
+  with_header <- sidrar:::.parse_sidra_values(
+    values_with_header_json(),
+    header = TRUE
+  )
+  without_header <- sidrar:::.parse_sidra_values(
+    values_without_header_json(),
+    header = FALSE
+  )
+
+  expect_s3_class(with_header, "data.frame")
+  expect_identical(nrow(with_header), 1L)
+  expect_identical(names(with_header), c(
+    "Nível Territorial (Código)", "Nível Territorial", "Valor"
+  ))
+  expect_equal(with_header$Valor, 0.16)
+
+  expect_identical(nrow(without_header), 1L)
+  expect_identical(names(without_header), c("NC", "NN", "V"))
+  expect_equal(without_header$V, 0.16)
+})
+
+test_that("SIDRA special values can be numeric, character, or both", {
+  text <- paste0(
+    '[{"V":"-"},{"V":"0"},{"V":"X"},',
+    '{"V":".."},{"V":"..."},{"V":"A"}]'
+  )
+
+  numeric <- sidrar:::.parse_sidra_values(text, FALSE, "numeric")
+  character <- sidrar:::.parse_sidra_values(text, FALSE, "character")
+  both <- sidrar:::.parse_sidra_values(text, FALSE, "both")
+
+  expect_true(is.na(numeric$V[[1L]]))
+  expect_equal(numeric$V[[2L]], 0)
+  expect_true(all(is.na(numeric$V[3:6])))
+  expect_identical(
+    character$V,
+    c("-", "0", "X", "..", "...", "A")
+  )
+  expect_identical(both$V_raw, character$V)
+  expect_equal(both$V, numeric$V)
+})
+
+test_that("malformed and empty responses fail with parse errors", {
+  expect_error(
+    sidrar:::.parse_sidra_values("", FALSE),
+    class = "sidrar_parse_error"
+  )
+  expect_error(
+    sidrar:::.parse_sidra_values("<html>error</html>", FALSE),
+    class = "sidrar_parse_error"
+  )
+  expect_error(
+    sidrar:::.parse_sidra_values("[]", TRUE),
+    "no header record",
+    class = "sidrar_parse_error"
+  )
+})
+
+test_that("get_sidra accepts full URLs and honors h/n", {
+  seen_url <- NULL
+  testthat::local_mocked_bindings(
+    .sidra_request = function(url) {
+      seen_url <<- url
+      values_without_header_json()
+    },
+    .package = "sidrar"
+  )
+
+  url <- paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/h/n"
+  )
+  expect_message(
+    result <- get_sidra(api = url),
+    "other arguments are ignored"
+  )
+
+  expect_identical(seen_url, url)
+  expect_identical(nrow(result), 1L)
+  expect_equal(result$V, 0.16)
+})
+
+test_that("documented vector queries work in modern R", {
+  seen_url <- NULL
+  testthat::local_mocked_bindings(
+    .sidra_request = function(url) {
+      seen_url <<- url
+      values_without_header_json()
+    },
+    .package = "sidrar"
+  )
+
+  result <- get_sidra(
+    x = 1378,
+    variable = 93,
+    geo = c("State", "City"),
+    geo.filter = list(Region = 3, Region = 3),
+    classific = c("c1", "c2"),
+    category = list(1),
+    header = FALSE
+  )
+
+  expect_s3_class(result, "data.frame")
+  expect_match(
+    seen_url,
+    "n3/in%20n2%203/n6/in%20n2%203",
+    fixed = TRUE
+  )
+  expect_match(seen_url, "/c1/1/c2/all", fixed = TRUE)
+})

--- a/tests/testthat/test-query-builders.R
+++ b/tests/testthat/test-query-builders.R
@@ -1,0 +1,173 @@
+test_that("the existing public argument order is preserved", {
+  existing <- c(
+    "x", "variable", "period", "geo", "geo.filter", "classific",
+    "category", "header", "format", "digits", "api"
+  )
+
+  expect_identical(names(formals(get_sidra))[seq_along(existing)], existing)
+  expect_identical(tail(names(formals(get_sidra)), 1L), "value_type")
+})
+
+test_that("geographic paths preserve requested order and filter association", {
+  expect_identical(
+    sidrar:::.build_geo_path("City", 5002704),
+    "n6/5002704"
+  )
+  expect_identical(
+    sidrar:::.build_geo_path(
+      c("State", "City"),
+      list(Region = 3, State = 50)
+    ),
+    "n3/in%20n2%203/n6/in%20n3%2050"
+  )
+  expect_identical(
+    sidrar:::.build_geo_path(
+      c("State", "City"),
+      list(Region = 3)
+    ),
+    "n3/in%20n2%203/n6/all"
+  )
+  expect_identical(
+    sidrar:::.build_geo_path("City", list(c(5002704, 5003702))),
+    "n6/5002704,5003702"
+  )
+})
+
+test_that("geographic validation handles vectors and invalid filters", {
+  expect_error(
+    sidrar:::.build_geo_path(character(), NULL),
+    "non-empty character"
+  )
+  expect_error(
+    sidrar:::.build_geo_path("State", list(City = 5002704)),
+    "geo.filter"
+  )
+  expect_error(
+    sidrar:::.build_geo_path("Unknown", NULL),
+    "misspecified"
+  )
+})
+
+test_that("classification categories are composed without being overwritten", {
+  expect_identical(
+    sidrar:::.build_classification_path(
+      c("c1", "c2", "c3"),
+      list(10, 20)
+    ),
+    "/c1/10/c2/20/c3/all"
+  )
+  expect_identical(
+    sidrar:::.build_classification_path(c(1, 2), list()),
+    "/c1/all/c2/all"
+  )
+  expect_error(
+    sidrar:::.build_classification_path("c1", c("one", "two")),
+    "type 'list'"
+  )
+})
+
+test_that("the default classification selection uses the JSON descriptor", {
+  testthat::local_mocked_bindings(
+    .fetch_descriptor = function(x) descriptor_fixture(),
+    .package = "sidrar"
+  )
+
+  query <- sidrar:::.build_sidra_query(
+    x = 1419,
+    variable = 63,
+    period = "last",
+    geo = "Brazil",
+    geo_filter = NULL,
+    classific = "all",
+    category = "all",
+    header = TRUE,
+    format = 4,
+    digits = "default"
+  )
+
+  expect_match(query$url, "/c315/all", fixed = TRUE)
+  expect_true(query$header)
+})
+
+test_that("period, variable, header, format, and digits are deterministic", {
+  expect_identical(
+    sidrar:::.build_period_path(c(last = 12)),
+    "last%2012"
+  )
+  expect_identical(
+    sidrar:::.build_period_path(c("2012", "2014-2016")),
+    "2012,2014-2016"
+  )
+  expect_identical(
+    sidrar:::.build_variable_path(c(63, 69)),
+    "63,69"
+  )
+  expect_identical(sidrar:::.build_header_path(FALSE), "n")
+  expect_error(sidrar:::.build_header_path(NA), "TRUE or FALSE")
+  expect_identical(sidrar:::.build_format_path(NULL), "/f/a")
+  expect_identical(sidrar:::.build_digits_path(NULL), "/d/s")
+
+  expect_warning(
+    format_path <- sidrar:::.build_format_path(99),
+    "default specification"
+  )
+  expect_identical(format_path, "/f/a")
+
+  expect_warning(
+    digits_path <- sidrar:::.build_digits_path("invalid"),
+    "default specification"
+  )
+  expect_identical(digits_path, "/d/s")
+})
+
+test_that("relative paths and full official URLs are accepted", {
+  expected <- paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/h/n"
+  )
+
+  expect_identical(
+    sidrar:::.normalize_api_url(
+      "/t/7060/n1/all/v/63/p/last/h/n"
+    ),
+    expected
+  )
+  expect_identical(
+    sidrar:::.normalize_api_url(
+      "t/7060/n1/all/v/63/p/last/h/n"
+    ),
+    expected
+  )
+  expect_identical(sidrar:::.normalize_api_url(expected), expected)
+  expect_identical(
+    sidrar:::.normalize_api_url(
+      "/values/t/7060/n1/all/v/63/p/last%2012/h/n"
+    ),
+    sub("/p/last/", "/p/last%2012/", expected, fixed = TRUE)
+  )
+  expect_false(sidrar:::.api_has_header(expected))
+  expect_true(
+    sidrar:::.api_has_header(
+      sub("/h/n", "", expected, fixed = TRUE)
+    )
+  )
+
+  expect_error(
+    sidrar:::.normalize_api_url(
+      "https://example.com/values/t/7060/n1/all"
+    ),
+    "official HTTPS"
+  )
+  expect_error(
+    sidrar:::.normalize_api_url(
+      paste0(expected, "?formato=xml")
+    ),
+    "Only JSON"
+  )
+  expect_error(
+    sidrar:::.normalize_api_url(
+      sub("https://", "http://", expected, fixed = TRUE)
+    ),
+    "official HTTPS"
+  )
+})

--- a/tests/testthat/test-search-sidra.R
+++ b/tests/testthat/test-search-sidra.R
@@ -29,6 +29,14 @@ test_that("search_sidra is accent and case insensitive", {
     c("1737" = "IPCA - Série histórica")
   )
   expect_identical(
+    search_sidra("VARIACAO"),
+    c("7060" = "IPCA - Variação mensal e acumulada")
+  )
+  expect_identical(
+    search_sidra("SE\u0301RIE HISTO\u0301RICA"),
+    c("1737" = "IPCA - Série histórica")
+  )
+  expect_identical(
     search_sidra(c("ipca", "acumulada")),
     c("7060" = "IPCA - Variação mensal e acumulada")
   )

--- a/tests/testthat/test-search-sidra.R
+++ b/tests/testthat/test-search-sidra.R
@@ -1,0 +1,37 @@
+test_that("search_sidra uses the official aggregate catalog", {
+  testthat::local_mocked_bindings(
+    .fetch_aggregate_catalog = catalog_fixture,
+    .package = "sidrar"
+  )
+
+  expect_identical(
+    search_sidra("ipca"),
+    c(
+      "7060" = "IPCA - Variação mensal e acumulada",
+      "1737" = "IPCA - Série histórica"
+    )
+  )
+  expect_identical(
+    search_sidra(c("contas", "nacionais")),
+    c("5932" = "Sistema de Contas Nacionais")
+  )
+  expect_identical(search_sidra("inexistente"), character())
+})
+
+test_that("search_sidra is accent and case insensitive", {
+  testthat::local_mocked_bindings(
+    .fetch_aggregate_catalog = catalog_fixture,
+    .package = "sidrar"
+  )
+
+  expect_identical(
+    search_sidra("SERIE HISTORICA"),
+    c("1737" = "IPCA - Série histórica")
+  )
+  expect_identical(
+    search_sidra(c("ipca", "acumulada")),
+    c("7060" = "IPCA - Variação mensal e acumulada")
+  )
+  expect_error(search_sidra(character()), "non-empty character")
+  expect_error(search_sidra(""), "empty search terms")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,81 @@
+test_that("successful HTTP responses are decoded as UTF-8 text", {
+  testthat::local_mocked_bindings(
+    RETRY = function(...) {
+      fake_http_response(body = '{"nome":"Variação"}')
+    },
+    .package = "httr"
+  )
+
+  text <- sidrar:::.sidra_request(
+    "https://apisidra.ibge.gov.br/values/t/1"
+  )
+  expect_identical(text, '{"nome":"Variação"}')
+})
+
+test_that("HTTP failures retain status and API details", {
+  testthat::local_mocked_bindings(
+    RETRY = function(...) {
+      fake_http_response(
+        status = 400L,
+        body = "Parâmetro de período inválido"
+      )
+    },
+    .package = "httr"
+  )
+
+  expect_error(
+    sidrar:::.sidra_request(
+      "https://apisidra.ibge.gov.br/values/t/1"
+    ),
+    regexp = "HTTP 400.*Parâmetro de período inválido",
+    class = "sidrar_http_error"
+  )
+})
+
+test_that("transport and empty-response failures use package error classes", {
+  testthat::local_mocked_bindings(
+    RETRY = function(...) stop("connection reset"),
+    .package = "httr"
+  )
+  expect_error(
+    sidrar:::.sidra_request(
+      "https://apisidra.ibge.gov.br/values/t/1"
+    ),
+    "connection reset",
+    class = "sidrar_http_error"
+  )
+
+  testthat::local_mocked_bindings(
+    RETRY = function(...) fake_http_response(body = ""),
+    .package = "httr"
+  )
+  expect_error(
+    sidrar:::.sidra_request(
+      "https://apisidra.ibge.gov.br/values/t/1"
+    ),
+    "empty response",
+    class = "sidrar_parse_error"
+  )
+})
+
+test_that("invalid request options fall back to safe defaults", {
+  seen_times <- NULL
+  old_options <- options(
+    sidrar.timeout = Inf,
+    sidrar.retries = Inf
+  )
+  on.exit(options(old_options), add = TRUE)
+
+  testthat::local_mocked_bindings(
+    RETRY = function(..., times) {
+      seen_times <<- times
+      fake_http_response()
+    },
+    .package = "httr"
+  )
+
+  sidrar:::.sidra_request(
+    "https://apisidra.ibge.gov.br/values/t/1"
+  )
+  expect_identical(seen_times, 3L)
+})

--- a/vignettes/Introduction_to_sidrar.Rmd
+++ b/vignettes/Introduction_to_sidrar.Rmd
@@ -1,165 +1,182 @@
 ---
 title: "Introduction to sidrar"
 author: "Renato Prado Siqueira"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Introduction to sidrar}
   %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, comment = "#>")
 ```
 
+## Overview
 
-## R Interface to the SIDRA's API
+`sidrar` is an R interface to SIDRA (*Sistema IBGE de Recuperação
+Automática*), the system through which the Brazilian Institute of Geography
+and Statistics (IBGE) publishes aggregate statistics.
 
-The "sidrar" R package seeks to provide direct access to the data of SIDRA - Sistema IBGE de Recuperação Automática - within the R environment in an easy and flexible way.
+The usual workflow is:
+
+1. find a table with `search_sidra()`;
+2. inspect its available dimensions with `info_sidra()`; and
+3. retrieve a selection with `get_sidra()`.
+
+Network-dependent examples are not evaluated while the vignette is built.
 
 ## Installation
 
-To install the version available on CRAN:
+Install the released version from CRAN:
 
-```{r, eval=FALSE}
+```{r, eval = FALSE}
 install.packages("sidrar")
 ```
 
-To install the development version hosted on Github:
+Install the development version from GitHub with `pak`:
 
-```{r, eval=FALSE}
-library(devtools)
-install_github("rpradosiqueira/sidrar")
+```{r, eval = FALSE}
+# install.packages("pak")
+pak::pak("rpradosiqueira/sidrar")
 ```
 
-## Functions
+## Find and inspect a table
 
-For the time being, the "sidra" package contains only three functions:
-
-```{r, eval=FALSE}
-get_sidra          It recovers data from the given table
-                   according to the parameters
-
-info_sidra         It allows you to check what parameters
-                   are available for a table via an web browser
-                   
-search_sidra       It searches which tables have a particular 
-                   word in their names
-```		   
-
-## Examples
-### get_sidra
-
-1) Let's assume that we want the IPCA (Índice de Preços ao Consumidor Amplo) for the city of Campo Grande/MS. However, we will only recover the overall percentage rate in the last 12 months. To do this simply execute:
+`search_sidra()` searches titles in IBGE's official aggregate catalog. Its
+result is a character vector whose names are the SIDRA table codes:
 
 ```{r, eval = FALSE}
 library(sidrar)
 
-get_sidra(x = 1419,
-          variable = 63,
-          period = c("last" = 12),
-          geo = "City",
-          geo.filter = 5002407,
-          classific = "c315",
-          category = list(7169),
-          header = FALSE,
-          format = 3)
-
+search_sidra("IPCA")
+search_sidra(c("contas", "nacionais"))
 ```
 
-```{r, echo = FALSE, eval=FALSE}
-## Tabela obtida
-library(sidrar)
+The search is case- and accent-insensitive. When several terms are supplied,
+all terms must occur in the title, but they need not be adjacent.
 
-get_sidra(x = 1419,
-          variable = 63,
-          period = c(last = "12"),
-          geo = "City",
-          geo.filter = 5002704,
-          classific = "c315",
-          category = list(7169),
-          header = FALSE,
-          format = 3)
-
-```
-
-<p> <br> </p>
-
-2) In this example we will download the Gini index data for the 2014 GDP of the states, containing only the codes in the table (format = 1):
+Once you have a code, inspect the periods, variables, classifications,
+categories, and territorial levels accepted by the table:
 
 ```{r, eval = FALSE}
-get_sidra(x = 5939,
-          variable = 529,
-          period = "2014",
-          geo = "State",
-          header = TRUE,
-          format = 1)
-
+metadata <- info_sidra(7060)
+names(metadata)
+metadata$variable
+metadata$classific_category
+metadata$geo
 ```
 
-```{r, echo = FALSE, eval=FALSE}
-get_sidra(x = 5939,
-          variable = 529,
-          period = "2014",
-          geo = "State",
-          header = TRUE,
-          format = 1)
-
-```
-
-<p> <br> </p>
-
-3) Finally, if you want to put the parameters of the API directly, just execute:
+Set `wb = TRUE` to open the official table descriptor in the default browser.
+The function no longer prompts for confirmation:
 
 ```{r, eval = FALSE}
-get_sidra(api = "/t/5938/n3/all/v/37/p/last%201/d/v37%200")
-
+info_sidra(7060, wb = TRUE)
 ```
 
-```{r, echo = FALSE, eval=FALSE}
-get_sidra(api = "/t/5938/n3/all/v/37/p/last%201/d/v37%200")
+## Build a structured request
 
+This request retrieves the monthly IPCA for the general index in Campo
+Grande, Mato Grosso do Sul, over the 12 most recent periods:
+
+```{r, eval = FALSE}
+ipca <- get_sidra(
+  x = 7060,
+  variable = 63,
+  period = c(last = 12),
+  geo = "City",
+  geo.filter = list(City = 5002704),
+  classific = "c315",
+  category = list(7169)
+)
 ```
 
-<p> <br> </p>
+`geo.filter` may also select every unit inside a higher territorial level.
+For example, the following pattern requests cities inside Mato Grosso do Sul:
 
-For most users the data request is done via the online portal (<https://sidra.ibge.gov.br>). In this case, if you want to save the parameters of the table selected in the portal to a posterior request of the same table via **sidrar**, you should copy the path in the red rectangle and pass to the *api* argument in get_sidra:         
-
-<p> <br> </p>
-
-![](fig2.png)
-
--------
-
-### info_sidra
-
-In the previous examples we know how to recover data from tables according to the parameters reported. However, if I do not know what the parameters are, how should I proceed? To verify the parameters (variables, classifications, periods, etc.) of a given table, simply use the function "info_sidra", informing the code of the table. The function returns a list with the possible parameters in the console. However, if wb = TRUE, the user can allow the result to be displayed in an web browser.
-
-```{r, echo = FALSE, eval=FALSE}
-info_sidra(5939)
+```{r, eval = FALSE}
+get_sidra(
+  x = 7060,
+  variable = 63,
+  period = "last",
+  geo = "City",
+  geo.filter = list(State = 50),
+  classific = "c315",
+  category = list(7169)
+)
 ```
 
-if **wb = TRUE**:
+The existing defaults remain unchanged: descriptive headers are enabled,
+`format = 4` requests codes and names, `digits = "default"` uses the table's
+standard precision, and `variable = "allxp"` excludes automatically generated
+percentage variables.
 
-```{r, eval=FALSE}
-info_sidra(5939, wb = TRUE)
+## Use an API path or full URL
+
+If a query was assembled elsewhere, pass either its path:
+
+```{r, eval = FALSE}
+get_sidra(
+  api = "/t/7060/n1/all/v/63/p/last/c315/7169"
+)
 ```
 
-```{r, echo=FALSE, error=TRUE}
-cat("Can the web browser be open? (y/n): ")
+or the complete official HTTPS URL:
+
+```{r, eval = FALSE}
+get_sidra(
+  api = paste0(
+    "https://apisidra.ibge.gov.br/values/",
+    "t/7060/n1/all/v/63/p/last/c315/7169"
+  )
+)
 ```
 
-By placing **y**, we have in this example:
+Full URLs are restricted to the official
+`https://apisidra.ibge.gov.br/values` endpoint. Percent-encoded segments such
+as `%20` are preserved. If the path contains `/h/n`, the first observation is
+kept as data instead of being interpreted as a header.
 
-![](fig1.png)
+## Preserve SIDRA's special values
 
--------
+SIDRA uses symbols with specific meanings, including `"-"` for an absolute
+zero, `"X"` for an inhibited value, `".."` when a value does not apply, and
+`"..."` when it is unavailable. Earlier versions returned a numeric `Valor`
+column, so special symbols became `NA`. That remains the default for
+compatibility.
 
-### search_sidra
+Use `value_type = "character"` to keep the symbols directly:
 
-If the user wants to know if there is a table that contains a certain term / word, simply use the function ** search_sidra ** informing the words of interest. The function returns the tables containing these terms in their headings.
-
-```{r, eval=FALSE}
-search_sidra(c("gini"))
+```{r, eval = FALSE}
+raw <- get_sidra(
+  api = "/t/1849/n3/all/v/811/p/2018/c12762/all",
+  value_type = "character"
+)
 ```
+
+Use `value_type = "both"` to keep numeric `Valor` and append `Valor_raw`:
+
+```{r, eval = FALSE}
+both <- get_sidra(
+  api = "/t/1849/n3/all/v/811/p/2018/c12762/all",
+  value_type = "both"
+)
+```
+
+## Network behavior
+
+Requests use HTTPS, UTF-8 decoding, an identifying user agent, a timeout, and
+limited retries for transient failures. Customize the timeout and retry count
+with:
+
+```{r, eval = FALSE}
+options(
+  sidrar.timeout = 120,
+  sidrar.retries = 4
+)
+```
+
+Invalid parameters and API limits are reported with the response returned by
+SIDRA. See the
+[official API help](https://apisidra.ibge.gov.br/home/ajuda) for the complete
+query syntax and current service limits.


### PR DESCRIPTION
## Summary

- migrate SIDRA metadata and search to the official JSON endpoints
- harden `get_sidra()` URL handling, retries, UTF-8 processing, and errors while preserving public contracts
- preserve special values through `value_type` and fix multi-geography/classification query construction
- add tests, current documentation, release notes, and CI

## Validation

- `R CMD check --as-cran --no-manual` (R 4.6.0, Windows 11): 0 errors, 0 warnings, 0 notes
- win-builder R-devel (Windows Server 2022): Status OK, including PDF and HTML manuals
- GitHub Actions R-CMD-check: 5/5 jobs passed (macOS release; Windows release; Ubuntu release, devel, and oldrel-1)
- 85 unit expectations passed
- 5 opt-in live SIDRA API scenarios passed
- 82.7% unit-test coverage
- audited current reverse imports: datazoom.amazonia, PNADCperiods, and SidraFacil

## Compatibility

The first 11 `get_sidra()` arguments/defaults, `data.frame` output, Portuguese header schema, numeric `Valor` default, percent-encoded API paths, and historical `info_sidra()` list components are preserved.

Closes #24
Closes #25
Addresses #16
Addresses #18

The complete-URL fix reported and proposed by @viniciusoike in #25/#26 is incorporated and credited in NEWS.
